### PR TITLE
✨ feat(fdm): add Dream and LLaDA support in FastDiffusionModel (#9)

### DIFF
--- a/tests/test_fast_diffusion_model.py
+++ b/tests/test_fast_diffusion_model.py
@@ -280,3 +280,195 @@ class TestGetPeftModel:
         )
         assert orig_lora_A.shape == loaded_lora_A.shape
         assert torch.allclose(orig_lora_A, loaded_lora_A)
+
+
+# ---------------------------------------------------------------------------
+# Dream model patching
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def tiny_dream_config():
+    from unturtle.models.dream.configuration_dream import DreamConfig
+
+    return DreamConfig(
+        vocab_size=512,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        max_position_embeddings=64,
+        mask_token_id=1,
+        pad_token_id=0,
+    )
+
+
+@pytest.fixture
+def tiny_dream_model(tiny_dream_config):
+    from unturtle.models.dream.modeling_dream import DreamModel
+
+    model = DreamModel(tiny_dream_config)
+    model.eval()
+    return model
+
+
+class TestDreamPatching:
+    def test_dream_peft_o_proj_patched(self, tiny_dream_model):
+        """After get_peft_model, o_proj layers should have apply_o=apply_lora_o."""
+        from unsloth.kernels.fast_lora import apply_lora_o
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        peft_model = FastDiffusionModel.get_peft_model(
+            tiny_dream_model,
+            r=4,
+            target_modules=["o_proj", "gate_proj", "up_proj", "down_proj"],
+            lora_alpha=4,
+            lora_dropout=0,
+            use_gradient_checkpointing=False,
+        )
+        for layer in peft_model.base_model.model.model.layers:
+            assert layer.self_attn.apply_o is apply_lora_o, (
+                f"apply_o not patched: {layer.self_attn.apply_o}"
+            )
+
+    def test_dream_peft_qkv_skipped(self, tiny_dream_model):
+        """QKV should NOT be patched for Dream (bias=True on q/k/v_proj)."""
+        from unsloth.kernels.fast_lora import apply_lora_qkv
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        peft_model = FastDiffusionModel.get_peft_model(
+            tiny_dream_model,
+            r=4,
+            target_modules=["q_proj", "k_proj", "v_proj", "o_proj"],
+            lora_alpha=4,
+            lora_dropout=0,
+            use_gradient_checkpointing=False,
+        )
+        for layer in peft_model.base_model.model.model.layers:
+            # apply_qkv should NOT be apply_lora_qkv (bias=True guard applies)
+            assert getattr(layer.self_attn, "apply_qkv", None) is not apply_lora_qkv, (
+                "apply_qkv should NOT be apply_lora_qkv for Dream (bias=True)"
+            )
+
+    def test_dream_peft_forward_runs(self, tiny_dream_model):
+        """Forward pass through a PEFT-wrapped Dream model should not raise."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        peft_model = FastDiffusionModel.get_peft_model(
+            tiny_dream_model,
+            r=4,
+            target_modules=["o_proj"],
+            lora_alpha=4,
+            lora_dropout=0,
+            use_gradient_checkpointing=False,
+        )
+        peft_model.eval()
+
+        B, L = 2, 8
+        input_ids = torch.randint(0, tiny_dream_model.config.vocab_size, (B, L))
+        with torch.no_grad():
+            out = peft_model(input_ids=input_ids)
+        # DreamModel returns MaskedLMOutput with logits
+        assert out.logits.shape == (B, L, tiny_dream_model.config.vocab_size)
+
+
+# ---------------------------------------------------------------------------
+# LLaDA model patching
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def tiny_llada_config():
+    from unturtle.models.llada.configuration_llada import LLaDAConfig
+
+    return LLaDAConfig(
+        d_model=64,
+        n_heads=4,
+        n_layers=2,
+        mlp_hidden_size=128,
+        vocab_size=512,
+        embedding_size=512,
+        max_sequence_length=64,
+        block_type="llama",
+        activation_type="silu",  # LLaDALlamaBlock does gate*up with silu (not swiglu split)
+        rope=True,
+        include_bias=False,
+        include_qkv_bias=False,
+        weight_tying=False,
+    )
+
+
+@pytest.fixture
+def tiny_llada_model(tiny_llada_config):
+    from unturtle.models.llada.modeling_llada import LLaDAModelLM
+
+    model = LLaDAModelLM(tiny_llada_config)
+    model.eval()
+    return model
+
+
+class TestLLaDAPatching:
+    def test_llada_peft_attn_out_patched(self, tiny_llada_model):
+        """After get_peft_model, attn_out in LLaDALlamaBlocks should have apply_o=apply_lora_o."""
+        from unsloth.kernels.fast_lora import apply_lora_o
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        peft_model = FastDiffusionModel.get_peft_model(
+            tiny_llada_model,
+            r=4,
+            target_modules=["q_proj", "k_proj", "v_proj", "attn_out"],
+            lora_alpha=4,
+            lora_dropout=0,
+            use_gradient_checkpointing=False,
+        )
+        from unturtle.models.llada.modeling_llada import LLaDALlamaBlock
+
+        # LLaDAModelLM wraps LLaDAModel in self.model
+        blocks = peft_model.base_model.model.model.transformer.blocks
+        for block in blocks:
+            if isinstance(block, LLaDALlamaBlock):
+                assert block.apply_o is apply_lora_o, (
+                    f"apply_o not patched on LLaDALlamaBlock: {block.apply_o}"
+                )
+
+    def test_llada_peft_qkv_patched(self, tiny_llada_model):
+        """LLaDALlamaBlock q/k/v_proj without bias should get apply_qkv=apply_lora_qkv."""
+        from unsloth.kernels.fast_lora import apply_lora_qkv
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        peft_model = FastDiffusionModel.get_peft_model(
+            tiny_llada_model,
+            r=4,
+            target_modules=["q_proj", "k_proj", "v_proj", "attn_out"],
+            lora_alpha=4,
+            lora_dropout=0,
+            use_gradient_checkpointing=False,
+        )
+        from unturtle.models.llada.modeling_llada import LLaDALlamaBlock
+
+        # LLaDAModelLM wraps LLaDAModel in self.model
+        blocks = peft_model.base_model.model.model.transformer.blocks
+        for block in blocks:
+            if isinstance(block, LLaDALlamaBlock):
+                assert block.apply_qkv is apply_lora_qkv, (
+                    f"apply_qkv not patched on LLaDALlamaBlock: {block.apply_qkv}"
+                )
+
+    def test_llada_peft_forward_runs(self, tiny_llada_model):
+        """Forward pass through a PEFT-wrapped LLaDA model should not raise."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        peft_model = FastDiffusionModel.get_peft_model(
+            tiny_llada_model,
+            r=4,
+            target_modules=["q_proj", "k_proj", "v_proj", "attn_out"],
+            lora_alpha=4,
+            lora_dropout=0,
+            use_gradient_checkpointing=False,
+        )
+        peft_model.eval()
+
+        B, L = 2, 8
+        input_ids = torch.randint(0, tiny_llada_model.config.vocab_size, (B, L))
+        with torch.no_grad():
+            out = peft_model(input_ids=input_ids)
+        assert out.logits.shape == (B, L, tiny_llada_model.config.vocab_size)

--- a/unturtle/fast_diffusion_model.py
+++ b/unturtle/fast_diffusion_model.py
@@ -79,6 +79,12 @@ _A2D_MODEL_TYPES = frozenset(
     ["a2d-llama", "a2d-qwen2", "a2d-qwen3", "llama", "qwen2", "qwen3"]
 )
 
+# Dream model_type (note: Dream uses "Dream" with capital D)
+_DREAM_MODEL_TYPES = frozenset(["dream", "Dream"])
+
+# LLaDA model_type
+_LLADA_MODEL_TYPES = frozenset(["llada"])
+
 
 # ---------------------------------------------------------------------------
 # Internal patching helpers
@@ -163,6 +169,191 @@ def _patch_a2d_peft(model: Any, lora_dropout: float, bias: Literal["none", "all"
         else:
             _warn_once(
                 "FastDiffusionModel: cannot patch O projection with Triton kernel."
+            )
+
+    return n_qkv, n_o, n_mlp
+
+
+def _patch_dream_peft(
+    model: Any, lora_dropout: float, bias: Literal["none", "all", "lora_only"]
+) -> tuple[int, int, int]:
+    """Patch Dream model with Triton LoRA kernels (o_proj + MLP only).
+
+    Dream's q/k/v_proj have ``bias=True``, so ``apply_lora_qkv`` cannot be
+    used (the bias guard would skip them).  We patch o_proj and MLP only and
+    emit a one-time warning about QKV.  QKV support requires a future
+    ``apply_lora_qkv_with_bias`` kernel (Issue #10).
+
+    Layer layout: ``model.base_model.model.model.layers``
+    (Dream wraps DreamBaseModel as ``self.model``, same depth as LLaMA).
+    """
+    n_qkv = n_o = n_mlp = 0
+
+    layers = model.base_model.model.model.layers
+
+    # Warn once that QKV is skipped for Dream
+    _warn_once(
+        "FastDiffusionModel (Dream): q/k/v_proj have bias=True — "
+        "Triton fused QKV kernel cannot be applied (see Issue #10). "
+        "LoRA on q/k/v_proj will use PEFT's default linear path."
+    )
+
+    for layer in layers:
+        self_attn = layer.self_attn if hasattr(layer, "self_attn") else None
+
+        if lora_dropout != 0 or bias != "none":
+            continue
+
+        if self_attn is None:
+            continue
+
+        # --- O projection (bias=False in Dream) ---
+        o_proj = self_attn.o_proj
+        if (
+            hasattr(o_proj, "lora_A")
+            and _no_bias(o_proj)
+            and _no_lora_mag(o_proj)
+        ):
+            self_attn.apply_o = apply_lora_o
+            n_o += 1
+
+        # --- MLP: Dream uses gate_proj/up_proj/down_proj (bias=False) ---
+        mlp = layer.mlp if hasattr(layer, "mlp") else None
+        if mlp is not None:
+            gate_proj = getattr(mlp, "gate_proj", None)
+            up_proj = getattr(mlp, "up_proj", None)
+            down_proj = getattr(mlp, "down_proj", None)
+            if (
+                gate_proj is not None
+                and up_proj is not None
+                and down_proj is not None
+                and hasattr(gate_proj, "lora_A")
+                and hasattr(up_proj, "lora_A")
+                and hasattr(down_proj, "lora_A")
+                and _no_bias(gate_proj)
+                and _no_bias(up_proj)
+                and _no_bias(down_proj)
+                and _no_lora_mag(gate_proj)
+                and _no_lora_mag(up_proj)
+                and _no_lora_mag(down_proj)
+            ):
+                mlp.forward = types.MethodType(apply_lora_mlp_swiglu, mlp)
+                n_mlp += 1
+
+    return n_qkv, n_o, n_mlp
+
+
+def _patch_llada_peft(
+    model: Any, lora_dropout: float, bias: Literal["none", "all", "lora_only"]
+) -> tuple[int, int, int]:
+    """Patch LLaDA model with Triton LoRA kernels.
+
+    LLaDA uses a non-standard layer hierarchy:
+      ``model.base_model.model.transformer.blocks`` (list of ``LLaDABlock``).
+
+    ``LLaDALlamaBlock`` has ``q_proj/k_proj/v_proj/attn_out/ff_proj/up_proj``.
+    Other block types (``LLaDASequentialBlock``) use ``att_proj`` (fused QKV)
+    and are not supported by the split QKV kernel — they are skipped with a
+    warning.
+    """
+    from unturtle.models.llada.modeling_llada import LLaDALlamaBlock
+
+    n_qkv = n_o = n_mlp = 0
+
+    # LLaDAModelLM wraps LLaDAModel in self.model, so the path differs:
+    # PeftModel → base_model → model (LLaDAModelLM) → model (LLaDAModel) → transformer
+    inner = model.base_model.model
+    if hasattr(inner, "model") and hasattr(inner.model, "transformer"):
+        transformer = inner.model.transformer
+    elif hasattr(inner, "transformer"):
+        transformer = inner.transformer
+    else:
+        _warn_once(
+            "FastDiffusionModel (LLaDA): could not locate transformer — "
+            "cannot patch LoRA kernels. Is this a supported LLaDA checkpoint?"
+        )
+        return n_qkv, n_o, n_mlp
+
+    if not hasattr(transformer, "blocks"):
+        _warn_once(
+            "FastDiffusionModel (LLaDA): transformer.blocks not found — "
+            "cannot patch LoRA kernels. Is this a supported LLaDA checkpoint?"
+        )
+        return n_qkv, n_o, n_mlp
+
+    blocks = transformer.blocks
+
+    for block in blocks:
+        if not isinstance(block, LLaDALlamaBlock):
+            _warn_once(
+                f"FastDiffusionModel (LLaDA): skipping block type {type(block).__name__} "
+                "(only LLaDALlamaBlock is supported for Triton LoRA patching)."
+            )
+            continue
+
+        if lora_dropout != 0 or bias != "none":
+            continue
+
+        # LLaDALlamaBlock: q_proj / k_proj / v_proj (bias depends on config)
+        q_proj = getattr(block, "q_proj", None)
+        k_proj = getattr(block, "k_proj", None)
+        v_proj = getattr(block, "v_proj", None)
+        if (
+            q_proj is not None
+            and k_proj is not None
+            and v_proj is not None
+            and hasattr(q_proj, "lora_A")
+            and hasattr(k_proj, "lora_A")
+            and hasattr(v_proj, "lora_A")
+            and _no_bias(q_proj)
+            and _no_bias(k_proj)
+            and _no_bias(v_proj)
+            and _no_lora_mag(q_proj)
+            and _no_lora_mag(k_proj)
+            and _no_lora_mag(v_proj)
+        ):
+            block.apply_qkv = apply_lora_qkv
+            n_qkv += 1
+        else:
+            _warn_once(
+                "FastDiffusionModel (LLaDA): cannot patch QKV with Triton kernel "
+                "(LoRA not enabled or bias present — config.include_qkv_bias=True)."
+            )
+
+        # attn_out (o_proj equivalent)
+        attn_out = getattr(block, "attn_out", None)
+        if (
+            attn_out is not None
+            and hasattr(attn_out, "lora_A")
+            and _no_bias(attn_out)
+            and _no_lora_mag(attn_out)
+        ):
+            block.apply_o = apply_lora_o
+            n_o += 1
+        else:
+            _warn_once(
+                "FastDiffusionModel (LLaDA): cannot patch attn_out with Triton kernel."
+            )
+
+        # ff_proj / up_proj (gate/up equivalent, no down_proj in LLaDA SwiGLU variant)
+        ff_proj = getattr(block, "ff_proj", None)
+        up_proj = getattr(block, "up_proj", None)
+        if (
+            ff_proj is not None
+            and up_proj is not None
+            and hasattr(ff_proj, "lora_A")
+            and hasattr(up_proj, "lora_A")
+            and _no_bias(ff_proj)
+            and _no_bias(up_proj)
+            and _no_lora_mag(ff_proj)
+            and _no_lora_mag(up_proj)
+        ):
+            # LLaDA SwiGLU has no down_proj — MLP packing not applicable to
+            # apply_lora_mlp_swiglu (which requires gate/up/down). Skip silently.
+            _warn_once(
+                "FastDiffusionModel (LLaDA): LLaDALlamaBlock MLP uses ff_proj/up_proj "
+                "without down_proj — apply_lora_mlp_swiglu requires gate/up/down. "
+                "MLP LoRA will use PEFT default path."
             )
 
     return n_qkv, n_o, n_mlp
@@ -371,10 +562,32 @@ class FastDiffusionModel:
                 f"{n_qkv} QKV layers, {n_o} O layers and {n_mlp} MLP layers "
                 f"(bidirectional, causal=False)."
             )
+        elif model_type in _DREAM_MODEL_TYPES:
+            n_qkv, n_o, n_mlp = _patch_dream_peft(model, lora_dropout, bias)
+            n_layers = len(model.base_model.model.model.layers)
+            _warn_once(
+                f"FastDiffusionModel (Dream) patched {n_layers} layers with "
+                f"{n_o} O layers and {n_mlp} MLP layers "
+                "(QKV skipped: bias=True, see Issue #10)."
+            )
+        elif model_type in _LLADA_MODEL_TYPES:
+            n_qkv, n_o, n_mlp = _patch_llada_peft(model, lora_dropout, bias)
+            inner = model.base_model.model
+            _llada_transformer = (
+                inner.model.transformer
+                if hasattr(inner, "model") and hasattr(inner.model, "transformer")
+                else getattr(inner, "transformer", None)
+            )
+            n_blocks = len(_llada_transformer.blocks) if _llada_transformer is not None else 0
+            _warn_once(
+                f"FastDiffusionModel (LLaDA) patched {n_blocks} blocks with "
+                f"{n_qkv} QKV blocks and {n_o} O (attn_out) blocks."
+            )
         else:
             raise NotImplementedError(
                 f"FastDiffusionModel does not yet support model_type={model_type!r}. "
-                "Supported types: " + ", ".join(sorted(_A2D_MODEL_TYPES))
+                "Supported types: "
+                + ", ".join(sorted(_A2D_MODEL_TYPES | _DREAM_MODEL_TYPES | _LLADA_MODEL_TYPES))
             )
 
         # Propagate max_seq_length through the wrapped model hierarchy


### PR DESCRIPTION
## Summary

- Add `_patch_dream_peft()`: patches `o_proj` + MLP with Triton LoRA kernels; QKV skipped (bias=True, tracked in Issue #10); emits one-time warning
- Add `_patch_llada_peft()`: resolves `transformer.blocks` path for `LLaDAModelLM` hierarchy, patches `LLaDALlamaBlock` `q/k/v_proj` (when bias-free) and `attn_out` via `apply_lora_o`
- Update `patch_peft_model()` dispatch to call new helpers for Dream and LLaDA model types

## Test plan

- [x] `TestDreamPatching::test_dream_peft_o_proj_patched` — `apply_o` set to `apply_lora_o` on all layers
- [x] `TestDreamPatching::test_dream_peft_qkv_skipped` — `apply_qkv` NOT set to `apply_lora_qkv` (bias guard)
- [x] `TestDreamPatching::test_dream_peft_forward_runs` — forward pass produces correct logit shape
- [x] `TestLLaDAPatching::test_llada_peft_attn_out_patched` — `attn_out` gets `apply_lora_o`
- [x] `TestLLaDAPatching::test_llada_peft_qkv_patched` — QKV blocks get `apply_lora_qkv` (no bias)
- [x] `TestLLaDAPatching::test_llada_peft_forward_runs` — forward pass produces correct logit shape
- [x] All 124 tests pass (`tests/diffusion/`, `tests/models/`, `tests/test_fast_diffusion_model.py`)

Closes #9