### PR TITLE
✨ feat(kernel): add apply_lora_qkv_with_bias for Dream QKV projections (#10)

### DIFF
--- a/tests/test_fast_diffusion_model.py
+++ b/tests/test_fast_diffusion_model.py
@@ -312,6 +312,97 @@ def tiny_dream_model(tiny_dream_config):
     return model
 
 
+# ---------------------------------------------------------------------------
+# LoRA_QKV_Bias kernel unit tests
+# ---------------------------------------------------------------------------
+
+class TestLoRAQKVBias:
+    """Unit tests for the LoRA_QKV_Bias autograd function."""
+
+    def test_output_shapes(self):
+        """LoRA_QKV_Bias.apply returns three tensors with correct shapes."""
+        from unturtle.kernels.fast_lora import LoRA_QKV_Bias
+
+        B, L, D, R = 2, 8, 32, 4
+        X = torch.randn(B, L, D, requires_grad=True)
+        # Simulate (W, W_quant=None, A, B, S, bias) for Q, K, V
+        QW = torch.randn(D, D)
+        KW = torch.randn(D, D)
+        VW = torch.randn(D, D)
+        QA = torch.randn(R, D)
+        QB = torch.randn(D, R)
+        KA = torch.randn(R, D)
+        KB = torch.randn(D, R)
+        VA = torch.randn(R, D)
+        VB = torch.randn(D, R)
+        QBias = torch.randn(D)
+        KBias = torch.randn(D)
+        VBias = torch.randn(D)
+        scale = 1.0
+
+        Q, K, V = LoRA_QKV_Bias.apply(
+            X,
+            QW, None, QA, QB, scale, QBias,
+            KW, None, KA, KB, scale, KBias,
+            VW, None, VA, VB, scale, VBias,
+            False,
+        )
+        assert Q.shape == (B, L, D)
+        assert K.shape == (B, L, D)
+        assert V.shape == (B, L, D)
+
+    def test_bias_is_applied(self):
+        """Setting bias to a constant vector shifts all outputs by that vector."""
+        from unturtle.kernels.fast_lora import LoRA_QKV_Bias
+
+        B, L, D, R = 1, 4, 16, 2
+        X = torch.zeros(B, L, D)  # zero input → W*0 = 0
+        W = torch.eye(D)
+        A = torch.zeros(R, D)
+        Bmat = torch.zeros(D, R)
+        bias = torch.ones(D) * 5.0
+        scale = 1.0
+
+        Q, K, V = LoRA_QKV_Bias.apply(
+            X,
+            W, None, A, Bmat, scale, bias,
+            W, None, A, Bmat, scale, bias,
+            W, None, A, Bmat, scale, bias,
+            False,
+        )
+        # With zero input and eye weight: W@X=0, LoRA=0, so output = bias
+        assert torch.allclose(Q, torch.ones(B, L, D) * 5.0)
+        assert torch.allclose(K, torch.ones(B, L, D) * 5.0)
+        assert torch.allclose(V, torch.ones(B, L, D) * 5.0)
+
+    def test_backward_runs(self):
+        """Backward pass through LoRA_QKV_Bias should not raise."""
+        from unturtle.kernels.fast_lora import LoRA_QKV_Bias
+
+        B, L, D, R = 2, 4, 16, 2
+        X = torch.randn(B, L, D, requires_grad=True)
+        QW = torch.randn(D, D, requires_grad=False)
+        QA = torch.randn(R, D, requires_grad=True)
+        QB = torch.randn(D, R, requires_grad=True)
+        QBias = torch.randn(D, requires_grad=True)
+        scale = 1.0
+
+        Q, K, V = LoRA_QKV_Bias.apply(
+            X,
+            QW, None, QA, QB, scale, QBias,
+            QW, None, QA, QB, scale, QBias,
+            QW, None, QA, QB, scale, QBias,
+            False,
+        )
+        loss = (Q + K + V).sum()
+        loss.backward()
+
+        assert X.grad is not None
+        assert QA.grad is not None
+        assert QB.grad is not None
+        assert QBias.grad is not None
+
+
 class TestDreamPatching:
     def test_dream_peft_o_proj_patched(self, tiny_dream_model):
         """After get_peft_model, o_proj layers should have apply_o=apply_lora_o."""
@@ -331,10 +422,10 @@ class TestDreamPatching:
                 f"apply_o not patched: {layer.self_attn.apply_o}"
             )
 
-    def test_dream_peft_qkv_skipped(self, tiny_dream_model):
-        """QKV should NOT be patched for Dream (bias=True on q/k/v_proj)."""
-        from unsloth.kernels.fast_lora import apply_lora_qkv
+    def test_dream_peft_qkv_uses_bias_kernel(self, tiny_dream_model):
+        """Dream q/k/v_proj (bias=True) should use apply_lora_qkv_with_bias."""
         from unturtle.fast_diffusion_model import FastDiffusionModel
+        from unturtle.kernels.fast_lora import apply_lora_qkv_with_bias
 
         peft_model = FastDiffusionModel.get_peft_model(
             tiny_dream_model,
@@ -345,9 +436,8 @@ class TestDreamPatching:
             use_gradient_checkpointing=False,
         )
         for layer in peft_model.base_model.model.model.layers:
-            # apply_qkv should NOT be apply_lora_qkv (bias=True guard applies)
-            assert getattr(layer.self_attn, "apply_qkv", None) is not apply_lora_qkv, (
-                "apply_qkv should NOT be apply_lora_qkv for Dream (bias=True)"
+            assert layer.self_attn.apply_qkv is apply_lora_qkv_with_bias, (
+                f"apply_qkv not set to apply_lora_qkv_with_bias: {layer.self_attn.apply_qkv}"
             )
 
     def test_dream_peft_forward_runs(self, tiny_dream_model):

--- a/unturtle/fast_diffusion_model.py
+++ b/unturtle/fast_diffusion_model.py
@@ -55,6 +55,7 @@ from unsloth.kernels.fast_lora import (
     apply_lora_o,
     apply_lora_qkv,
 )
+from unturtle.kernels.fast_lora import apply_lora_qkv_with_bias
 from unsloth.models._utils import prepare_model_for_kbit_training
 from unsloth.save import patch_saving_functions
 
@@ -177,12 +178,12 @@ def _patch_a2d_peft(model: Any, lora_dropout: float, bias: Literal["none", "all"
 def _patch_dream_peft(
     model: Any, lora_dropout: float, bias: Literal["none", "all", "lora_only"]
 ) -> tuple[int, int, int]:
-    """Patch Dream model with Triton LoRA kernels (o_proj + MLP only).
+    """Patch Dream model with Triton LoRA kernels.
 
-    Dream's q/k/v_proj have ``bias=True``, so ``apply_lora_qkv`` cannot be
-    used (the bias guard would skip them).  We patch o_proj and MLP only and
-    emit a one-time warning about QKV.  QKV support requires a future
-    ``apply_lora_qkv_with_bias`` kernel (Issue #10).
+    Dream's q/k/v_proj have ``bias=True``, so the standard ``apply_lora_qkv``
+    is replaced with ``apply_lora_qkv_with_bias`` (``LoRA_QKV_Bias`` kernel).
+    o_proj (bias=False) uses the standard ``apply_lora_o``.
+    MLP (gate/up/down, all bias=False) uses ``apply_lora_mlp_swiglu``.
 
     Layer layout: ``model.base_model.model.model.layers``
     (Dream wraps DreamBaseModel as ``self.model``, same depth as LLaMA).
@@ -190,13 +191,6 @@ def _patch_dream_peft(
     n_qkv = n_o = n_mlp = 0
 
     layers = model.base_model.model.model.layers
-
-    # Warn once that QKV is skipped for Dream
-    _warn_once(
-        "FastDiffusionModel (Dream): q/k/v_proj have bias=True — "
-        "Triton fused QKV kernel cannot be applied (see Issue #10). "
-        "LoRA on q/k/v_proj will use PEFT's default linear path."
-    )
 
     for layer in layers:
         self_attn = layer.self_attn if hasattr(layer, "self_attn") else None
@@ -207,10 +201,34 @@ def _patch_dream_peft(
         if self_attn is None:
             continue
 
-        # --- O projection (bias=False in Dream) ---
-        o_proj = self_attn.o_proj
+        # --- QKV: Dream has bias=True → use apply_lora_qkv_with_bias ---
+        q_proj = getattr(self_attn, "q_proj", None)
+        k_proj = getattr(self_attn, "k_proj", None)
+        v_proj = getattr(self_attn, "v_proj", None)
         if (
-            hasattr(o_proj, "lora_A")
+            q_proj is not None
+            and k_proj is not None
+            and v_proj is not None
+            and hasattr(q_proj, "lora_A")
+            and hasattr(k_proj, "lora_A")
+            and hasattr(v_proj, "lora_A")
+            and _no_lora_mag(q_proj)
+            and _no_lora_mag(k_proj)
+            and _no_lora_mag(v_proj)
+        ):
+            self_attn.apply_qkv = apply_lora_qkv_with_bias
+            n_qkv += 1
+        else:
+            _warn_once(
+                "FastDiffusionModel (Dream): cannot patch QKV with Triton kernel "
+                "(LoRA adapters not enabled or lora_magnitude_vector present)."
+            )
+
+        # --- O projection (bias=False in Dream) ---
+        o_proj = getattr(self_attn, "o_proj", None)
+        if (
+            o_proj is not None
+            and hasattr(o_proj, "lora_A")
             and _no_bias(o_proj)
             and _no_lora_mag(o_proj)
         ):
@@ -567,8 +585,7 @@ class FastDiffusionModel:
             n_layers = len(model.base_model.model.model.layers)
             _warn_once(
                 f"FastDiffusionModel (Dream) patched {n_layers} layers with "
-                f"{n_o} O layers and {n_mlp} MLP layers "
-                "(QKV skipped: bias=True, see Issue #10)."
+                f"{n_qkv} QKV layers (bias kernel), {n_o} O layers and {n_mlp} MLP layers."
             )
         elif model_type in _LLADA_MODEL_TYPES:
             n_qkv, n_o, n_mlp = _patch_llada_peft(model, lora_dropout, bias)

--- a/unturtle/kernels/__init__.py
+++ b/unturtle/kernels/__init__.py
@@ -30,8 +30,14 @@ from .masked_diffusion_loss import (
     fast_masked_diffusion_loss,
     masked_diffusion_loss_from_timesteps,
 )
+from .fast_lora import (
+    LoRA_QKV_Bias,
+    apply_lora_qkv_with_bias,
+)
 
 __all__ = [
     "fast_masked_diffusion_loss",
     "masked_diffusion_loss_from_timesteps",
+    "LoRA_QKV_Bias",
+    "apply_lora_qkv_with_bias",
 ]

--- a/unturtle/kernels/fast_lora.py
+++ b/unturtle/kernels/fast_lora.py
@@ -1,0 +1,213 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Triton-fused LoRA kernel extensions for dLLM models.
+
+Provides ``apply_lora_qkv_with_bias``: the bias-aware variant of unsloth's
+``apply_lora_qkv`` kernel needed for Dream's ``q/k/v_proj`` layers which have
+``bias=True``.
+
+Mathematics::
+
+    Q = X @ Wq.T + bq + (X @ Aq.T) @ Bq.T * Sq
+    K = X @ Wk.T + bk + (X @ Ak.T) @ Bk.T * Sk
+    V = X @ Wv.T + bv + (X @ Av.T) @ Bv.T * Sv
+
+The weight-update part is identical to ``LoRA_QKV``; this class adds the bias
+addition in forward and the bias gradient (``dQ.sum(0)`` etc.) in backward.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from unsloth.kernels.fast_lora import (
+    LoRA_QKV,
+    apply_lora_qkv,  # re-export for convenience
+    apply_lora_o,
+    apply_lora_mlp_swiglu,
+)
+from unsloth.kernels.utils import (
+    _maybe_fake_quantize_activations,
+    fast_dequantize,
+    get_lora_parameters_bias,
+    matmul_lora,
+    torch_amp_custom_bwd,
+    torch_amp_custom_fwd,
+)
+
+__all__ = [
+    "LoRA_QKV",
+    "LoRA_QKV_Bias",
+    "apply_lora_qkv",
+    "apply_lora_qkv_with_bias",
+    "apply_lora_o",
+    "apply_lora_mlp_swiglu",
+]
+
+
+class LoRA_QKV_Bias(torch.autograd.Function):
+    """Fused QKV LoRA with bias support.
+
+    Identical to :class:`unsloth.kernels.fast_lora.LoRA_QKV` except each
+    projection's bias is added after the matmul (forward) and the bias
+    gradients are accumulated in backward.
+
+    Args order matches ``LoRA_QKV`` with three extra bias args appended:
+    ``Qbias, Kbias, Vbias``.
+    """
+
+    @staticmethod
+    @torch_amp_custom_fwd
+    def forward(
+        ctx,
+        X: torch.Tensor,
+        QW,
+        QW_quant,
+        QA,
+        QB,
+        QS,
+        QBias,
+        KW,
+        KW_quant,
+        KA,
+        KB,
+        KS,
+        KBias,
+        VW,
+        VW_quant,
+        VA,
+        VB,
+        VS,
+        VBias,
+        inplace: bool = True,
+    ):
+        orig_shape = X.shape
+        X_for_matmul = X.view(-1, X.shape[-1]) if X.dim() == 3 else X
+
+        Q = matmul_lora(X_for_matmul, QW, QW_quant, QA, QB, QS)
+        K = matmul_lora(X_for_matmul, KW, KW_quant, KA, KB, KS)
+        V = matmul_lora(X_for_matmul, VW, VW_quant, VA, VB, VS)
+
+        if len(orig_shape) == 3:
+            Q = Q.view(orig_shape[0], orig_shape[1], -1)
+            K = K.view(orig_shape[0], orig_shape[1], -1)
+            V = V.view(orig_shape[0], orig_shape[1], -1)
+
+        # Add biases (broadcast over batch and sequence dimensions)
+        if QBias is not None:
+            Q = Q + QBias
+        if KBias is not None:
+            K = K + KBias
+        if VBias is not None:
+            V = V + VBias
+
+        ctx.custom_saved_tensors = (
+            QW, QW_quant, QS,
+            KW, KW_quant, KS,
+            VW, VW_quant, VS,
+        )
+        ctx.save_for_backward(X, QA, QB, KA, KB, VA, VB)
+        ctx.inplace = inplace
+        ctx.has_bias = (QBias is not None, KBias is not None, VBias is not None)
+        return Q, K, V
+
+    @staticmethod
+    @torch_amp_custom_bwd
+    def backward(ctx, dQ, dK, dV):
+        QW, QW_quant, QS, KW, KW_quant, KS, VW, VW_quant, VS = ctx.custom_saved_tensors
+        X, QA, QB, KA, KB, VA, VB = ctx.saved_tensors
+        has_Qb, has_Kb, has_Vb = ctx.has_bias
+
+        batch, seq_len, hd = X.shape
+        dQ = dQ.reshape(-1, dQ.shape[-1])
+        dK = dK.reshape(-1, dK.shape[-1])
+        dV = dV.reshape(-1, dV.shape[-1])
+        X = X.reshape(-1, X.shape[-1])
+        dtype = X.dtype
+
+        QA, QB = QA.to(dtype).t(), QB.to(dtype).t()
+        KA, KB = KA.to(dtype).t(), KB.to(dtype).t()
+        VA, VB = VA.to(dtype).t(), VB.to(dtype).t()
+
+        d_QA = torch.empty_like(QA)
+        d_QB = torch.empty_like(QB)
+        d_KA = torch.empty_like(KA)
+        d_KB = torch.empty_like(KB)
+        d_VA = torch.empty_like(VA)
+        d_VB = torch.empty_like(VB)
+
+        d_QA.addmm_(X.t(), dQ @ QB.t(), alpha=QS, beta=0)
+        d_QB.addmm_(QA.t() @ X.t(), dQ, alpha=QS, beta=0)
+
+        d_KA.addmm_(X.t(), dK @ KB.t(), alpha=KS, beta=0)
+        d_KB.addmm_(KA.t() @ X.t(), dK, alpha=KS, beta=0)
+
+        d_VA.addmm_(X.t(), dV @ VB.t(), alpha=VS, beta=0)
+        d_VB.addmm_(VA.t() @ X.t(), dV, alpha=VS, beta=0)
+
+        # dX
+        QW = fast_dequantize(QW.t(), QW_quant)
+        dX = torch.matmul(dQ, QW.t(), out=X if ctx.inplace else None)
+        del QW
+        dX.addmm_(dQ @ QB.t(), QA.t(), alpha=QS)
+
+        KW = fast_dequantize(KW.t(), KW_quant)
+        dX.addmm_(dK, KW.t())
+        del KW
+        dX.addmm_(dK @ KB.t(), KA.t(), alpha=KS)
+
+        VW = fast_dequantize(VW.t(), VW_quant)
+        dX.addmm_(dV, VW.t())
+        del VW
+        dX.addmm_(dV @ VB.t(), VA.t(), alpha=VS)
+
+        # Bias gradients: sum over batch*seq dims
+        d_QBias = dQ.sum(0) if has_Qb else None
+        d_KBias = dK.sum(0) if has_Kb else None
+        d_VBias = dV.sum(0) if has_Vb else None
+
+        # X, QW, QW_quant, QA, QB, QS, QBias,
+        # KW, KW_quant, KA, KB, KS, KBias,
+        # VW, VW_quant, VA, VB, VS, VBias, inplace
+        return (
+            dX.view(batch, seq_len, hd),
+            None, None, d_QA.t(), d_QB.t(), None, d_QBias,
+            None, None, d_KA.t(), d_KB.t(), None, d_KBias,
+            None, None, d_VA.t(), d_VB.t(), None, d_VBias,
+            None,
+        )
+
+
+def apply_lora_qkv_with_bias(self, X, inplace: bool = True):
+    """Bias-aware drop-in for ``apply_lora_qkv``.
+
+    Use this as ``self_attn.apply_qkv`` for models where ``q/k/v_proj``
+    have ``bias=True`` (e.g. Dream).
+
+    Reads parameters via ``get_lora_parameters_bias`` which returns a
+    6-tuple ``(W, W_quant, A, B, S, bias)``.
+    """
+    X = _maybe_fake_quantize_activations(X, self.q_proj)
+    QW, QW_quant, QA, QB, QS, QBias = get_lora_parameters_bias(self.q_proj)
+    KW, KW_quant, KA, KB, KS, KBias = get_lora_parameters_bias(self.k_proj)
+    VW, VW_quant, VA, VB, VS, VBias = get_lora_parameters_bias(self.v_proj)
+    Q, K, V = LoRA_QKV_Bias.apply(
+        X,
+        QW, QW_quant, QA, QB, QS, QBias,
+        KW, KW_quant, KA, KB, KS, KBias,
+        VW, VW_quant, VA, VB, VS, VBias,
+        inplace,
+    )
+    return Q, K, V


### PR DESCRIPTION
## Summary

- Add `LoRA_QKV_Bias` autograd Function: extends `LoRA_QKV` with bias support in forward (adds `bq/bk/bv`) and backward (`dQ.sum(0)` etc.)
- Add `apply_lora_qkv_with_bias()` using `get_lora_parameters_bias` (6-tuple `W, W_quant, A, B, S, bias`)
- Update `_patch_dream_peft()` to use `apply_lora_qkv_with_bias` — Dream's `q/k/v_proj` (bias=True) are now fully Triton-fused
- New `unturtle/kernels/fast_lora.py` as canonical home for unturtle kernel extensions

## Test plan

- [x] `TestLoRAQKVBias::test_output_shapes` — Q/K/V have correct shapes
- [x] `TestLoRAQKVBias::test_bias_is_applied` — zero input + constant bias → output equals bias
- [x] `TestLoRAQKVBias::test_backward_runs` — gradients flow to X, A, B, bias
- [x] `TestDreamPatching::test_dream_peft_qkv_uses_bias_kernel` — `apply_qkv` set to `apply_lora_qkv_with_bias`
- [x] All 127 tests pass

Closes #10