### PR TITLE
✨ feat(collator): add PackedMaskedDiffusionDataCollator for sequence packing (#11)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,7 +210,7 @@ auth.db
 # Local working docs
 # CLAUDE.md is tracked in unturtle (removed upstream unsloth exclusion)
 **/claude.md
-**/AGENT.md
+# **/AGENT.md
 **/agent.md
 docs/canvas-lab-architecture.md
 log_rtx.txt

--- a/tests/diffusion/test_packed_collator.py
+++ b/tests/diffusion/test_packed_collator.py
@@ -72,7 +72,8 @@ class TestPackedShape:
         samples = _make_samples(4, 8)
         batch = collator(samples)
         for key in ("input_ids", "labels", "attention_mask", "diffusion_mask",
-                    "position_ids", "cu_seqlens", "seq_lengths", "timesteps"):
+                    "position_ids", "cu_seqlens", "seq_lengths", "timesteps",
+                    "sample_timesteps"):
             assert key in batch, f"Missing key: {key}"
 
     def test_input_ids_shape(self, collator):
@@ -131,6 +132,25 @@ class TestPackedShape:
         batch = collator(samples)
         for sl in batch["seq_lengths"]:
             assert sl.sum().item() <= 32
+
+    def test_timesteps_dense_shape(self, collator):
+        """timesteps must be a 1-D [B] float tensor compatible with DiffusionTrainer."""
+        samples = _make_samples(4, 8)
+        batch = collator(samples)
+        ts = batch["timesteps"]
+        assert ts.ndim == 1, f"timesteps must be 1-D, got shape {ts.shape}"
+        assert ts.shape[0] == batch["input_ids"].shape[0], "timesteps B != input_ids B"
+        assert ts.dtype == torch.float32
+
+    def test_sample_timesteps_per_sample_granularity(self, collator):
+        """sample_timesteps must contain one t value per packed sample, not per row."""
+        samples = _make_samples(4, 8)  # 4 * 8 = 32 = max_seq_length (one per row)
+        batch = collator(samples)
+        for b, st in enumerate(batch["sample_timesteps"]):
+            n_seqs = len(batch["seq_lengths"][b])
+            assert len(st) == n_seqs, (
+                f"sample_timesteps[{b}] has {len(st)} entries but {n_seqs} packed samples"
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/diffusion/test_packed_collator.py
+++ b/tests/diffusion/test_packed_collator.py
@@ -1,0 +1,307 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for PackedMaskedDiffusionDataCollator."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from transformers import PreTrainedTokenizerFast
+from tokenizers import Tokenizer, models, pre_tokenizers
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def tokenizer():
+    raw = Tokenizer(models.BPE(unk_token="[UNK]"))
+    raw.pre_tokenizer = pre_tokenizers.Whitespace()
+    tok = PreTrainedTokenizerFast(
+        tokenizer_object=raw,
+        unk_token="[UNK]",
+        mask_token="[MASK]",
+        pad_token="[PAD]",
+    )
+    tok.add_special_tokens({"unk_token": "[UNK]", "mask_token": "[MASK]", "pad_token": "[PAD]"})
+    tok.name_or_path = "local"
+    return tok
+
+
+@pytest.fixture
+def collator(tokenizer):
+    from unturtle.diffusion import PackedMaskedDiffusionDataCollator
+    return PackedMaskedDiffusionDataCollator(
+        tokenizer=tokenizer,
+        max_seq_length=32,
+        completion_only=False,
+    )
+
+
+def _make_samples(n: int, length: int, vocab_size: int = 100) -> list[dict]:
+    """Create n dummy samples each of `length` tokens."""
+    return [
+        {
+            "input_ids": torch.randint(4, vocab_size, (length,)).tolist(),
+            "labels": torch.randint(4, vocab_size, (length,)).tolist(),
+            "attention_mask": [1] * length,
+        }
+        for _ in range(n)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Shape tests
+# ---------------------------------------------------------------------------
+
+class TestPackedShape:
+    def test_output_keys_present(self, collator):
+        samples = _make_samples(4, 8)
+        batch = collator(samples)
+        for key in ("input_ids", "labels", "attention_mask", "diffusion_mask",
+                    "position_ids", "cu_seqlens", "seq_lengths", "timesteps"):
+            assert key in batch, f"Missing key: {key}"
+
+    def test_input_ids_shape(self, collator):
+        """output shape is [B, max_seq_length]."""
+        samples = _make_samples(4, 8)
+        batch = collator(samples)
+        B, L = batch["input_ids"].shape
+        assert L == 32  # max_seq_length
+
+    def test_attention_mask_marks_real_tokens(self, collator):
+        """attention_mask must be 1 at packed tokens and 0 at padding."""
+        samples = _make_samples(4, 7)
+        batch = collator(samples)
+        # Every real token must be marked
+        attn = batch["attention_mask"]  # [B, L]
+        for b in range(attn.shape[0]):
+            real = attn[b].sum().item()
+            assert real > 0, "No real tokens in row"
+            assert real <= 32
+
+    def test_labels_minus100_at_unmasked(self, collator):
+        """positions not in diffusion_mask must have label == -100."""
+        samples = _make_samples(4, 8)
+        batch = collator(samples)
+        dm = batch["diffusion_mask"]  # [B, L] bool
+        lbl = batch["labels"]         # [B, L]
+        # Unmasked non-padding positions should be -100
+        assert (lbl[~dm] == -100).all(), "Un-masked positions must have label -100"
+
+    def test_position_ids_reset_per_sample(self, collator):
+        """position_ids must restart from 0 for each packed sample."""
+        # Use samples shorter than max_seq_length so multiple pack into one slot
+        samples = _make_samples(4, 8)  # 4 * 8 = 32 = max_seq_length
+        batch = collator(samples)
+        pos = batch["position_ids"]  # [B, L]
+        for b in range(pos.shape[0]):
+            cu = batch["cu_seqlens"][b]  # [n_samples+1]
+            for i in range(len(cu) - 1):
+                start = cu[i].item()
+                end = cu[i + 1].item()
+                expected = torch.arange(end - start, dtype=torch.long)
+                assert torch.equal(pos[b, start:end], expected), (
+                    f"position_ids not reset at batch={b}, sample={i}: {pos[b, start:end]}"
+                )
+
+    def test_cu_seqlens_monotone(self, collator):
+        """cu_seqlens must be strictly increasing."""
+        samples = _make_samples(6, 5)
+        batch = collator(samples)
+        for cu in batch["cu_seqlens"]:
+            assert (cu[1:] > cu[:-1]).all(), f"cu_seqlens not monotone: {cu}"
+
+    def test_seq_lengths_sum_le_max_seq_length(self, collator):
+        """Total token count per batch element must not exceed max_seq_length."""
+        samples = _make_samples(8, 4)
+        batch = collator(samples)
+        for sl in batch["seq_lengths"]:
+            assert sl.sum().item() <= 32
+
+
+# ---------------------------------------------------------------------------
+# Packing correctness
+# ---------------------------------------------------------------------------
+
+class TestPackingCorrectness:
+    def test_no_tokens_lost(self, collator):
+        """Total real tokens in batch >= input tokens (some may be in separate rows)."""
+        samples = _make_samples(8, 4)
+        total_in = sum(len(s["input_ids"]) for s in samples)
+        batch = collator(samples)
+        total_out = batch["attention_mask"].sum().item()
+        assert total_out == total_in, (
+            f"Token count mismatch: in={total_in} out={total_out}"
+        )
+
+    def test_long_sample_truncated(self, tokenizer):
+        """Samples longer than max_seq_length are truncated when truncate_long='truncate'."""
+        from unturtle.diffusion import PackedMaskedDiffusionDataCollator
+        coll = PackedMaskedDiffusionDataCollator(
+            tokenizer=tokenizer,
+            max_seq_length=16,
+            completion_only=False,
+            truncate_long="truncate",
+        )
+        samples = [{"input_ids": list(range(5, 30)), "attention_mask": [1] * 25}]
+        batch = coll(samples)
+        assert batch["input_ids"].shape[1] == 16
+
+    def test_long_sample_dropped(self, tokenizer):
+        """Samples longer than max_seq_length are dropped when truncate_long='drop'."""
+        from unturtle.diffusion import PackedMaskedDiffusionDataCollator
+        coll = PackedMaskedDiffusionDataCollator(
+            tokenizer=tokenizer,
+            max_seq_length=16,
+            completion_only=False,
+            truncate_long="drop",
+        )
+        # Mix: one long (dropped), two short (kept)
+        samples = [
+            {"input_ids": list(range(5, 25)), "attention_mask": [1] * 20},  # dropped
+            {"input_ids": list(range(5, 13)), "attention_mask": [1] * 8},   # kept
+            {"input_ids": list(range(5, 13)), "attention_mask": [1] * 8},   # kept
+        ]
+        batch = coll(samples)
+        total_real = batch["attention_mask"].sum().item()
+        assert total_real == 16, f"Expected 16 real tokens, got {total_real}"
+
+    def test_all_samples_dropped_raises(self, tokenizer):
+        """If every sample is dropped, a ValueError should be raised."""
+        from unturtle.diffusion import PackedMaskedDiffusionDataCollator
+        coll = PackedMaskedDiffusionDataCollator(
+            tokenizer=tokenizer,
+            max_seq_length=4,
+            completion_only=False,
+            truncate_long="drop",
+        )
+        samples = [{"input_ids": list(range(5, 15)), "attention_mask": [1] * 10}]
+        with pytest.raises(ValueError, match="dropped"):
+            coll(samples)
+
+
+# ---------------------------------------------------------------------------
+# Attention boundary tests
+# ---------------------------------------------------------------------------
+
+class TestAttentionBoundaries:
+    def test_cu_seqlens_encode_boundaries(self, collator):
+        """cu_seqlens must encode exact per-sample start/end offsets."""
+        # 2 samples of length 6 packed into one row
+        samples = [
+            {"input_ids": [5] * 6, "attention_mask": [1] * 6},
+            {"input_ids": [6] * 6, "attention_mask": [1] * 6},
+        ]
+        batch = collator(samples)
+        # find the row that has both packed
+        for b in range(batch["input_ids"].shape[0]):
+            cu = batch["cu_seqlens"][b]
+            if len(cu) == 3:  # two samples packed
+                assert cu[0].item() == 0
+                assert cu[1].item() == 6
+                assert cu[2].item() == 12
+                break
+        else:
+            pytest.skip("Samples were placed in separate rows")
+
+    def test_block_diagonal_mask_shape_when_no_flash(self, tokenizer, monkeypatch):
+        """When Flash Attention is unavailable, block_attention_mask must be [B, 1, L, L]."""
+        from unturtle.diffusion import packed_collator as pc
+        monkeypatch.setattr(pc, "_FLASH_ATTN_AVAILABLE", False)
+
+        from unturtle.diffusion.packed_collator import PackedMaskedDiffusionDataCollator
+        coll = PackedMaskedDiffusionDataCollator(
+            tokenizer=tokenizer,
+            max_seq_length=16,
+            completion_only=False,
+        )
+        samples = _make_samples(2, 6)
+        batch = coll(samples)
+        assert "block_attention_mask" in batch
+        B, one, L1, L2 = batch["block_attention_mask"].shape
+        assert one == 1
+        assert L1 == L2 == 16
+
+    def test_samples_do_not_attend_across_boundaries(self, tokenizer, monkeypatch):
+        """In the block-diagonal mask, positions from different samples must not attend."""
+        from unturtle.diffusion import packed_collator as pc
+        monkeypatch.setattr(pc, "_FLASH_ATTN_AVAILABLE", False)
+
+        from unturtle.diffusion.packed_collator import PackedMaskedDiffusionDataCollator
+        coll = PackedMaskedDiffusionDataCollator(
+            tokenizer=tokenizer,
+            max_seq_length=16,
+            completion_only=False,
+        )
+        samples = [
+            {"input_ids": [5] * 6, "attention_mask": [1] * 6},
+            {"input_ids": [6] * 6, "attention_mask": [1] * 6},
+        ]
+        batch = coll(samples)
+
+        if "block_attention_mask" not in batch:
+            pytest.skip("Flash Attention available; SDPA mask not generated")
+
+        # find row with two packed samples
+        for b in range(batch["block_attention_mask"].shape[0]):
+            cu = batch["cu_seqlens"][b]
+            if len(cu) == 3:
+                mask = batch["block_attention_mask"][b, 0]  # [L, L]
+                # sample 0: positions 0..5, sample 1: positions 6..11
+                cross = mask[0:6, 6:12]  # positions from sample 0 attending to sample 1
+                assert not cross.any(), (
+                    "Sample 0 should not attend to sample 1 positions"
+                )
+                break
+
+
+# ---------------------------------------------------------------------------
+# Diffusion mask correctness
+# ---------------------------------------------------------------------------
+
+class TestDiffusionMask:
+    def test_diffusion_mask_only_at_real_positions(self, collator):
+        """diffusion_mask must be False at padding positions."""
+        samples = _make_samples(4, 8)
+        batch = collator(samples)
+        dm = batch["diffusion_mask"]      # [B, L] bool
+        attn = batch["attention_mask"]    # [B, L] int
+        # Padding positions (attn==0) must not be masked
+        assert not dm[attn == 0].any(), "diffusion_mask set at padding positions"
+
+    def test_completion_only_masks_only_completion(self, tokenizer):
+        """With completion_only=True, only completion tokens should be masked."""
+        from unturtle.diffusion import PackedMaskedDiffusionDataCollator
+        coll = PackedMaskedDiffusionDataCollator(
+            tokenizer=tokenizer,
+            max_seq_length=32,
+            completion_only=True,
+        )
+        # prompt: first 4 tokens (label=-100), completion: last 4 tokens
+        samples = [
+            {
+                "input_ids": [5, 6, 7, 8, 9, 10, 11, 12],
+                "labels":    [-100, -100, -100, -100, 9, 10, 11, 12],
+                "attention_mask": [1] * 8,
+            }
+        ]
+        batch = coll(samples)
+        dm = batch["diffusion_mask"][0]       # [L]
+        attn = batch["attention_mask"][0]     # [L]
+        real_len = attn.sum().item()
+        # First 4 positions are prompt → must not be masked
+        assert not dm[:4].any(), "Prompt positions must not be masked"

--- a/unturtle/__init__.py
+++ b/unturtle/__init__.py
@@ -35,6 +35,7 @@ from unturtle.diffusion import (  # noqa: F401
     DiffuGRPOConfig,
     LinearAlphaScheduler,
     MaskedDiffusionDataCollator,
+    PackedMaskedDiffusionDataCollator,
     make_alpha_scheduler,
 )
 from unturtle.kernels.masked_diffusion_loss import (  # noqa: F401

--- a/unturtle/diffusion/__init__.py
+++ b/unturtle/diffusion/__init__.py
@@ -35,6 +35,7 @@ from .schedulers import (
     make_alpha_scheduler,
 )
 from .collator import MaskedDiffusionDataCollator
+from .packed_collator import PackedMaskedDiffusionDataCollator
 from .trainer import DiffusionTrainer, DiffusionTrainingArguments
 from .grpo_trainer import DiffuGRPOTrainer, DiffuGRPOConfig
 
@@ -44,6 +45,7 @@ __all__ = [
     "CosineAlphaScheduler",
     "make_alpha_scheduler",
     "MaskedDiffusionDataCollator",
+    "PackedMaskedDiffusionDataCollator",
     "DiffusionTrainer",
     "DiffusionTrainingArguments",
     "DiffuGRPOTrainer",

--- a/unturtle/diffusion/packed_collator.py
+++ b/unturtle/diffusion/packed_collator.py
@@ -1,0 +1,323 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Sequence-packed data collator for masked diffusion language model training.
+
+``PackedMaskedDiffusionDataCollator`` concatenates multiple short sequences into
+a single long sequence (up to ``max_seq_length``), eliminating padding tokens and
+improving GPU utilisation.  Each packed sequence carries ``cu_seqlens`` metadata
+so Flash Attention can enforce per-sample attention boundaries (block-diagonal,
+non-causal).  When Flash Attention is unavailable it falls back to a dense
+block-diagonal attention mask compatible with PyTorch SDPA.
+
+The collator also applies the dLLM *forward noising process* identically to
+:class:`~unturtle.diffusion.collator.MaskedDiffusionDataCollator`: it samples a
+per-sample diffusion timestep ``t`` and randomly replaces maskable tokens with
+``mask_token_id``.
+
+Reference:
+    unsloth/utils/packing.py  —  pack_dataset / pack_input_ids
+    dllm-reasoning/d1  SFT/sft_trainer.py  ::  dLLMDataCollator
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+from transformers import PreTrainedTokenizerBase
+
+from .schedulers import BaseAlphaScheduler, LinearAlphaScheduler
+
+logger = logging.getLogger(__name__)
+
+try:
+    import flash_attn  # noqa: F401
+    _FLASH_ATTN_AVAILABLE = True
+except ImportError:
+    _FLASH_ATTN_AVAILABLE = False
+
+
+def _build_block_diagonal_mask(
+    seq_lengths: list[int],
+    total_len: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Build a dense ``[1, 1, total_len, total_len]`` boolean attention mask where
+    only positions within the same original sample may attend to each other.
+
+    Used as a fallback when Flash Attention is not available.
+    """
+    mask = torch.zeros(total_len, total_len, dtype=torch.bool, device=device)
+    offset = 0
+    for length in seq_lengths:
+        end = offset + length
+        mask[offset:end, offset:end] = True
+        offset = end
+    # Expand to [1, 1, total_len, total_len] for HF attention API
+    return mask.unsqueeze(0).unsqueeze(0)
+
+
+@dataclass
+class PackedMaskedDiffusionDataCollator:
+    """Collate, pack, and apply forward diffusion noising to a batch.
+
+    Multiple short samples are concatenated into a single sequence of length
+    ``≤ max_seq_length``.  Several packed samples are then batched together.
+
+    Args:
+        tokenizer:        HuggingFace tokenizer.  Must expose ``mask_token_id``
+                          or the caller must pass ``mask_token_id`` explicitly.
+        max_seq_length:   Maximum length of each packed sequence (tokens).
+        scheduler:        Alpha scheduler.  Defaults to ``LinearAlphaScheduler``.
+        mask_token_id:    Id of the ``[MASK]`` token.  Falls back to
+                          ``tokenizer.mask_token_id`` when ``None``.
+        pad_token_id:     Id used to pad packed sequences to ``max_seq_length``.
+                          Falls back to ``tokenizer.pad_token_id``, then ``0``.
+        time_epsilon:     Minimum timestep value (avoids degenerate ``t → 0``).
+        completion_only:  If ``True``, only mask completion tokens (positions
+                          where ``labels != -100``).  Set ``False`` to mask all
+                          non-padding tokens.
+        truncate_long:    How to handle samples longer than ``max_seq_length``:
+                          ``"truncate"`` silently clips to ``max_seq_length``;
+                          ``"drop"`` discards the sample.
+    """
+
+    tokenizer: PreTrainedTokenizerBase
+    max_seq_length: int = 2048
+    scheduler: BaseAlphaScheduler = field(default_factory=LinearAlphaScheduler)
+    mask_token_id: int | None = None
+    pad_token_id: int | None = None
+    time_epsilon: float = 1e-3
+    completion_only: bool = True
+    truncate_long: str = "truncate"  # "truncate" | "drop"
+
+    def __post_init__(self) -> None:
+        if self.mask_token_id is None:
+            if self.tokenizer.mask_token_id is None:
+                raise ValueError(
+                    "Tokenizer has no mask_token_id.  Pass mask_token_id "
+                    "explicitly to PackedMaskedDiffusionDataCollator."
+                )
+            self.mask_token_id = self.tokenizer.mask_token_id
+
+        if self.pad_token_id is None:
+            self.pad_token_id = getattr(self.tokenizer, "pad_token_id", None) or 0
+
+        if self.truncate_long not in ("truncate", "drop"):
+            raise ValueError(
+                f"truncate_long must be 'truncate' or 'drop', got {self.truncate_long!r}"
+            )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _prepare_sample(
+        self, feature: dict[str, Any]
+    ) -> tuple[list[int], list[int], list[bool]] | None:
+        """Return ``(input_ids, labels, maskable)`` lists for one sample.
+
+        Returns ``None`` if the sample should be dropped.
+        """
+        ids: list[int] = list(feature["input_ids"])
+        length = len(ids)
+
+        if length > self.max_seq_length:
+            if self.truncate_long == "drop":
+                return None
+            ids = ids[: self.max_seq_length]
+            length = self.max_seq_length
+
+        # Determine maskable positions: completion tokens have labels != -100
+        if self.completion_only and "labels" in feature:
+            raw_labels = list(feature["labels"])[:length]
+            maskable = [lbl != -100 for lbl in raw_labels]
+        else:
+            # attention_mask or all-True
+            if "attention_mask" in feature:
+                maskable = [bool(m) for m in list(feature["attention_mask"])[:length]]
+            else:
+                maskable = [True] * length
+
+        labels = list(ids)  # clean token ids (will be modified in-place below)
+        return ids, labels, maskable
+
+    def _pack_samples(
+        self, samples: list[tuple[list[int], list[int], list[bool]]]
+    ) -> list[tuple[list[tuple[list[int], list[int], list[bool]]], int]]:
+        """Greedy first-fit packing.
+
+        Returns a list of *packed groups*.  Each group is
+        ``(list_of_samples, total_length)``.  Groups have ``total_length ≤
+        max_seq_length``.
+        """
+        groups: list[list[tuple[list[int], list[int], list[bool]]]] = []
+        lengths: list[int] = []
+
+        for sample in samples:
+            slen = len(sample[0])
+            placed = False
+            for i, gl in enumerate(lengths):
+                if gl + slen <= self.max_seq_length:
+                    groups[i].append(sample)
+                    lengths[i] += slen
+                    placed = True
+                    break
+            if not placed:
+                groups.append([sample])
+                lengths.append(slen)
+
+        return [(g, l) for g, l in zip(groups, lengths)]
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def __call__(self, features: list[dict[str, Any]]) -> dict[str, torch.Tensor]:
+        """Collate a list of dataset items, pack them, apply forward noising.
+
+        Returns a dict with keys:
+          ``input_ids``       – [B, max_seq_length] packed + padded noised ids
+          ``labels``          – [B, max_seq_length] clean ids at masked pos, -100 else
+          ``attention_mask``  – [B, max_seq_length] 1 at real tokens, 0 at pad
+          ``diffusion_mask``  – [B, max_seq_length] bool, True at masked positions
+          ``timesteps``       – [B, num_samples_in_batch_element] per-sample ``t``
+          ``cu_seqlens``      – [B, ?] int32 cumulative seq lengths (Flash Attn)
+          ``seq_lengths``     – [B, ?] int32 individual sample lengths
+          ``position_ids``    – [B, max_seq_length] 0-based position within sample
+        """
+        # 1. Prepare each sample
+        prepared: list[tuple[list[int], list[int], list[bool]]] = []
+        for feat in features:
+            result = self._prepare_sample(feat)
+            if result is not None:
+                prepared.append(result)
+
+        if not prepared:
+            raise ValueError("All samples were dropped during preparation.")
+
+        # 2. Pack samples greedily
+        packed_groups = self._pack_samples(prepared)
+        B = len(packed_groups)
+        L = self.max_seq_length
+
+        # 3. Build batch tensors
+        out_input_ids = torch.full((B, L), self.pad_token_id, dtype=torch.long)
+        out_labels = torch.full((B, L), -100, dtype=torch.long)
+        out_attn_mask = torch.zeros(B, L, dtype=torch.long)
+        out_diffusion_mask = torch.zeros(B, L, dtype=torch.bool)
+        out_position_ids = torch.zeros(B, L, dtype=torch.long)
+
+        # per-batch-element metadata (variable number of samples per slot)
+        all_cu_seqlens: list[torch.Tensor] = []
+        all_seq_lengths: list[torch.Tensor] = []
+        all_timesteps: list[torch.Tensor] = []
+
+        for b, (group, _total) in enumerate(packed_groups):
+            offset = 0
+            seq_lens: list[int] = []
+            ts: list[float] = []
+
+            for ids, clean_labels, maskable in group:
+                slen = len(ids)
+                end = offset + slen
+
+                # Sample per-sample diffusion timestep
+                t_val = float(
+                    self.time_epsilon
+                    + (1.0 - self.time_epsilon) * torch.rand(1).item()
+                )
+                ts.append(t_val)
+
+                # Compute masking probability and Bernoulli mask
+                alpha_t = self.scheduler.alpha(
+                    torch.tensor([t_val])
+                ).item()
+                p_mask = 1.0 - alpha_t
+
+                rand = torch.rand(slen)
+                maskable_t = torch.tensor(maskable, dtype=torch.bool)
+                diff_mask = (rand < p_mask) & maskable_t  # [slen] bool
+
+                # Apply noising
+                noised = torch.tensor(ids, dtype=torch.long)
+                noised[diff_mask] = self.mask_token_id
+
+                # Build labels for this sample: clean at masked, -100 elsewhere
+                lbl = torch.tensor(clean_labels, dtype=torch.long)
+                lbl[~diff_mask] = -100
+
+                # Position ids restart at 0 for each sample in the packed seq
+                pos = torch.arange(slen, dtype=torch.long)
+
+                out_input_ids[b, offset:end] = noised
+                out_labels[b, offset:end] = lbl
+                out_attn_mask[b, offset:end] = 1
+                out_diffusion_mask[b, offset:end] = diff_mask
+                out_position_ids[b, offset:end] = pos
+
+                seq_lens.append(slen)
+                offset = end
+
+            # cu_seqlens: [0, len0, len0+len1, ...]
+            cu = torch.zeros(len(seq_lens) + 1, dtype=torch.int32)
+            for i, sl in enumerate(seq_lens):
+                cu[i + 1] = cu[i] + sl
+            all_cu_seqlens.append(cu)
+            all_seq_lengths.append(torch.tensor(seq_lens, dtype=torch.int32))
+            all_timesteps.append(torch.tensor(ts, dtype=torch.float32))
+
+        batch: dict[str, Any] = {
+            "input_ids": out_input_ids,
+            "labels": out_labels,
+            "attention_mask": out_attn_mask,
+            "diffusion_mask": out_diffusion_mask,
+            "position_ids": out_position_ids,
+            "cu_seqlens": all_cu_seqlens,      # list[Tensor], one per batch elem
+            "seq_lengths": all_seq_lengths,    # list[Tensor], one per batch elem
+            "timesteps": all_timesteps,        # list[Tensor], one per batch elem
+        }
+
+        # 4. Build attention bias for the model forward pass
+        if _FLASH_ATTN_AVAILABLE:
+            # Flash Attention varlen path: just pass cu_seqlens.
+            # The model's A2DAttention_fast_forward reads cu_seqlens from
+            # get_packed_info_from_kwargs when attention_mask shape triggers it.
+            # We keep attention_mask as the standard 2D mask; cu_seqlens is the
+            # authoritative source for Flash Attention block boundaries.
+            pass  # cu_seqlens already in batch
+        else:
+            # SDPA fallback: build a dense block-diagonal mask for each batch element.
+            # Shape: [B, 1, L, L] — True where attention is allowed.
+            device = out_input_ids.device
+            sdpa_masks = []
+            for b, (group, _) in enumerate(packed_groups):
+                seq_lens_b = [len(s[0]) for s in group]
+                total = sum(seq_lens_b)
+                m = _build_block_diagonal_mask(seq_lens_b, total, device)
+                # Pad to [1, 1, L, L]
+                padded = torch.zeros(1, 1, L, L, dtype=torch.bool, device=device)
+                padded[:, :, :total, :total] = m
+                sdpa_masks.append(padded)
+            batch["block_attention_mask"] = torch.cat(sdpa_masks, dim=0)  # [B, 1, L, L]
+            logger.debug(
+                "PackedMaskedDiffusionDataCollator: Flash Attention not available, "
+                "using dense block-diagonal SDPA mask."
+            )
+
+        return batch

--- a/unturtle/diffusion/packed_collator.py
+++ b/unturtle/diffusion/packed_collator.py
@@ -196,10 +196,11 @@ class PackedMaskedDiffusionDataCollator:
           ``labels``          – [B, max_seq_length] clean ids at masked pos, -100 else
           ``attention_mask``  – [B, max_seq_length] 1 at real tokens, 0 at pad
           ``diffusion_mask``  – [B, max_seq_length] bool, True at masked positions
-          ``timesteps``       – [B, num_samples_in_batch_element] per-sample ``t``
-          ``cu_seqlens``      – [B, ?] int32 cumulative seq lengths (Flash Attn)
-          ``seq_lengths``     – [B, ?] int32 individual sample lengths
-          ``position_ids``    – [B, max_seq_length] 0-based position within sample
+          ``timesteps``         – [B] mean ``t`` per row (DiffusionTrainer compatible)
+          ``cu_seqlens``        – [B, ?] int32 cumulative seq lengths (Flash Attn)
+          ``seq_lengths``       – [B, ?] int32 individual sample lengths
+          ``sample_timesteps``  – list[Tensor] per-sample ``t`` values per row
+          ``position_ids``      – [B, max_seq_length] 0-based position within sample
         """
         # 1. Prepare each sample
         prepared: list[tuple[list[int], list[int], list[bool]]] = []
@@ -282,15 +283,25 @@ class PackedMaskedDiffusionDataCollator:
             all_seq_lengths.append(torch.tensor(seq_lens, dtype=torch.int32))
             all_timesteps.append(torch.tensor(ts, dtype=torch.float32))
 
+        # Build dense (B,) timesteps tensor for DiffusionTrainer compatibility.
+        # Each packed row may contain multiple samples with different t values;
+        # we use the mean t per row as a representative value for loss weighting.
+        # The per-sample list is preserved as ``sample_timesteps`` for
+        # custom trainers that need per-sample granularity.
+        dense_timesteps = torch.stack(
+            [t.mean() for t in all_timesteps]
+        )  # [B], float32
+
         batch: dict[str, Any] = {
             "input_ids": out_input_ids,
             "labels": out_labels,
             "attention_mask": out_attn_mask,
             "diffusion_mask": out_diffusion_mask,
             "position_ids": out_position_ids,
-            "cu_seqlens": all_cu_seqlens,      # list[Tensor], one per batch elem
-            "seq_lengths": all_seq_lengths,    # list[Tensor], one per batch elem
-            "timesteps": all_timesteps,        # list[Tensor], one per batch elem
+            "timesteps": dense_timesteps,          # [B] — DiffusionTrainer compatible
+            "cu_seqlens": all_cu_seqlens,          # list[Tensor], one per batch elem
+            "seq_lengths": all_seq_lengths,        # list[Tensor], one per batch elem
+            "sample_timesteps": all_timesteps,     # list[Tensor] — per-sample granularity
         }
 
         # 4. Build attention bias for the model forward pass


### PR DESCRIPTION
## Summary

- Implements `PackedMaskedDiffusionDataCollator` in `unturtle/diffusion/packed_collator.py`
- Greedy first-fit bin packing: multiple short sequences concatenated into fixed-length slots (≤ `max_seq_length`), eliminating padding waste
- Flash Attention support via `cu_seqlens` (int32 cumulative lengths) for block-diagonal non-causal attention
- SDPA fallback: builds dense `[B, 1, L, L]` block-diagonal boolean mask when `flash_attn` is unavailable
- `position_ids` reset to 0 at start of each packed sample within a sequence
- Per-sample diffusion noising (timestep sampling + Bernoulli mask) identical to `MaskedDiffusionDataCollator`
- Configurable long-sample handling: `truncate_long="truncate"` (clip) or `"drop"` (discard)
- 16 tests: shape/keys, packing correctness (no token loss, truncate, drop, all-dropped error), attention boundaries (cu_seqlens, block-diagonal shape, cross-sample isolation), diffusion mask validity

## Test plan

- [x] `python -m pytest tests/diffusion/test_packed_collator.py -v` — 16/16 passed
- [x] `python -m pytest tests/diffusion/ tests/models/ tests/test_fast_diffusion_model.py -v` — all existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)