### PR TITLE
✨ feat(packing): add Flash varlen compaction for A2D packed attention (#22)

### DIFF
--- a/tests/models/test_a2d.py
+++ b/tests/models/test_a2d.py
@@ -281,3 +281,116 @@ class TestA2DPackedForward:
         assert lengths.tolist() == [8, 8]
         assert cu_seqlens.tolist() == [0, 8, 16]
         assert max_seqlen == 8
+
+
+# ---------------------------------------------------------------------------
+# Flash varlen compaction helper
+# ---------------------------------------------------------------------------
+
+
+class TestFlashVarlenCompaction:
+    """Tests for _flash_varlen_packed: compaction and scatter logic."""
+
+    def test_compaction_token_count_and_values(self):
+        """Compact slices have correct total count and preserve token values."""
+        B, n_heads, L, head_dim = 2, 4, 16, 8
+        # row0: 2 samples × 6 tokens = 12 real; row1: 1 sample × 10 tokens = 10 real
+        seq_lengths_list = [
+            torch.tensor([6, 6], dtype=torch.int32),
+            torch.tensor([10], dtype=torch.int32),
+        ]
+        real_counts = [12, 10]
+        total_tokens = 22
+
+        Q_t = torch.randn(B, L, n_heads, head_dim)
+        compact = torch.cat([Q_t[b, :real_counts[b]] for b in range(B)], dim=0)
+
+        assert compact.shape[0] == total_tokens
+        assert torch.allclose(compact[:12], Q_t[0, :12])
+        assert torch.allclose(compact[12:], Q_t[1, :10])
+
+    def test_scatter_is_inverse_of_compact(self):
+        """Scatter back into padded buffer is lossless; padding positions remain zero."""
+        B, n_heads, L, head_dim = 2, 4, 16, 8
+        real_counts = [12, 10]
+        total_tokens = 22
+
+        fake_out = torch.randn(total_tokens, n_heads, head_dim)
+        out_full = torch.zeros(B, L, n_heads * head_dim)
+
+        offset = 0
+        for b in range(B):
+            rc = real_counts[b]
+            out_full[b, :rc] = fake_out[offset:offset + rc].reshape(rc, n_heads * head_dim)
+            offset += rc
+
+        assert torch.all(out_full[0, 12:] == 0), "Row 0 padding must be zero"
+        assert torch.all(out_full[1, 10:] == 0), "Row 1 padding must be zero"
+
+        offset = 0
+        for b in range(B):
+            rc = real_counts[b]
+            expected = fake_out[offset:offset + rc].reshape(rc, n_heads * head_dim)
+            assert torch.allclose(out_full[b, :rc], expected), f"Row {b} values mismatch"
+            offset += rc
+
+    @pytest.mark.skipif(
+        not torch.cuda.is_available(), reason="CUDA required for Flash Attention"
+    )
+    def test_flash_varlen_packed_gpu_shape_and_bidirectionality(self):
+        """Flash varlen output has correct shape; bidirectionality is preserved."""
+        try:
+            from flash_attn import flash_attn_varlen_func  # noqa: F401
+        except ImportError:
+            pytest.skip("flash_attn not installed")
+
+        from unturtle.models.a2d._fast_forward import _flash_varlen_packed
+
+        B, n_heads, L, head_dim = 2, 4, 16, 8
+        n_kv_heads = n_heads
+        device = "cuda"
+
+        seq_lengths_list = [
+            torch.tensor([6, 6], dtype=torch.int32),   # row0: 12 real, 4 padding
+            torch.tensor([10], dtype=torch.int32),     # row1: 10 real, 6 padding
+        ]
+
+        torch.manual_seed(42)
+        Q = torch.randn(B, n_heads, L, head_dim, device=device, dtype=torch.bfloat16)
+        K = torch.randn(B, n_kv_heads, L, head_dim, device=device, dtype=torch.bfloat16)
+        V = torch.randn(B, n_kv_heads, L, head_dim, device=device, dtype=torch.bfloat16)
+
+        out = _flash_varlen_packed(
+            Q, K, V,
+            seq_lengths_list=seq_lengths_list,
+            n_heads=n_heads,
+            n_kv_heads=n_kv_heads,
+            head_dim=head_dim,
+        )
+
+        assert out.shape == (B, L, n_heads * head_dim)
+        assert torch.all(out[0, 12:] == 0), "Row 0 padding must be zero"
+        assert torch.all(out[1, 10:] == 0), "Row 1 padding must be zero"
+
+        # Bidirectionality test: change V at position 5 (last token of sample0, positions 0-5).
+        # Since causal=False, position 0 (same sample) attends to position 5 — output should change.
+        # Position 6 (start of sample1, positions 6-11) must NOT change — cross-sample blocked.
+        V_fwd = V.clone()
+        V_fwd[0, :, 5, :] = torch.randn(n_kv_heads, head_dim, device=device, dtype=torch.bfloat16)
+        out_fwd = _flash_varlen_packed(
+            Q, K, V_fwd,
+            seq_lengths_list=seq_lengths_list,
+            n_heads=n_heads,
+            n_kv_heads=n_kv_heads,
+            head_dim=head_dim,
+        )
+        # Position 0 (sample0) attends to position 5 (same sample) → output changes
+        assert not torch.allclose(out[0, 0].float(), out_fwd[0, 0].float(), atol=1e-3), (
+            "Position 0 should change when V at position 5 (same sample) changes — "
+            "bidirectional attention not working"
+        )
+        # Position 6 (sample1) does NOT attend to position 5 (sample0) → output unchanged
+        assert torch.allclose(out[0, 6].float(), out_fwd[0, 6].float(), atol=1e-3), (
+            "Position 6 (sample1) should NOT change when V at position 5 (sample0) changes — "
+            "cross-sample attention should be blocked by cu_seqlens"
+        )

--- a/unturtle/models/a2d/_fast_forward.py
+++ b/unturtle/models/a2d/_fast_forward.py
@@ -218,7 +218,7 @@ def A2DAttention_fast_forward(
 
     if use_varlen:
         seq_lengths_list = kwargs.get("seq_lengths", None)
-        if HAS_FLASH_ATTENTION and seq_lengths_list is not None:
+        if HAS_FLASH_ATTENTION and Q.device.type == "cuda" and seq_lengths_list is not None:
             # Flash varlen path: compact padding tokens out, call flash_attn_varlen_func
             # directly (bypasses run_attention which does uncompacted reshape).
             A = _flash_varlen_packed(

--- a/unturtle/models/a2d/_fast_forward.py
+++ b/unturtle/models/a2d/_fast_forward.py
@@ -39,6 +39,7 @@ from transformers.cache_utils import Cache
 
 from unsloth.kernels.rope_embedding import fast_rope_embedding
 from unsloth.utils.attention_dispatch import (
+    HAS_FLASH_ATTENTION,
     SDPA,
     AttentionConfig,
     AttentionContext,
@@ -46,6 +47,9 @@ from unsloth.utils.attention_dispatch import (
     select_attention_backend,
 )
 from unsloth.utils.packing import get_packed_info_from_kwargs
+
+if HAS_FLASH_ATTENTION:
+    from flash_attn import flash_attn_varlen_func
 
 
 def _rotate_half_rope(
@@ -67,6 +71,81 @@ def _rotate_half_rope(
     Q_out = Q * cos + _rotate_half(Q) * sin
     K_out = K * cos + _rotate_half(K) * sin
     return Q_out, K_out
+
+
+def _flash_varlen_packed(
+    Q: torch.Tensor,              # [B, n_heads, L, head_dim]
+    K: torch.Tensor,              # [B, n_kv_heads, L, head_dim]
+    V: torch.Tensor,              # [B, n_kv_heads, L, head_dim]
+    seq_lengths_list: list,       # list[Tensor] — seq_lengths_list[b] = int32 lengths for row b
+    n_heads: int,
+    n_kv_heads: int,
+    head_dim: int,
+) -> torch.Tensor:
+    """Compact Q/K/V to padding-free buffers, run flash_attn_varlen_func, scatter back.
+
+    Each row b in the batch has ``sum(seq_lengths_list[b])`` real tokens followed by
+    padding.  This function:
+      1. Strips padding from each row and concatenates into a flat compacted buffer.
+      2. Calls ``flash_attn_varlen_func`` with ``causal=False`` (bidirectional dLLM).
+      3. Scatters the output back into a zero-padded ``[B, L, n_heads * head_dim]`` tensor.
+
+    flash_attn handles GQA natively: Q has ``n_heads`` heads, K/V have ``n_kv_heads``.
+
+    Returns:
+        Tensor of shape ``[B, L, n_heads * head_dim]`` with zeros at padding positions.
+    """
+    bsz = Q.shape[0]
+    q_len = Q.shape[2]
+
+    # Compute real token count per row (tiny CPU ops — seq_lengths are small)
+    real_counts = [int(sl.sum().item()) for sl in seq_lengths_list]
+    total_tokens = sum(real_counts)
+
+    # Build per-sample cu_seqlens for flash_attn_varlen_func.
+    # Concatenate all per-row length tensors → flat [total_samples] vector.
+    # cu_seqlens indexes into the compacted buffer (sample-level boundaries).
+    flat_lengths = torch.cat(
+        [sl.to(device=Q.device, dtype=torch.int32) for sl in seq_lengths_list]
+    )  # [total_samples_across_all_rows]
+    cu_seqlens = torch.zeros(flat_lengths.numel() + 1, dtype=torch.int32, device=Q.device)
+    torch.cumsum(flat_lengths, dim=0, out=cu_seqlens[1:])
+    max_seqlen = int(flat_lengths.max().item())
+
+    # Compact: remove padding, concatenate real tokens from all rows.
+    # Q: [B, n_heads, L, head_dim] → transpose → [B, L, n_heads, head_dim] → slice + cat
+    Q_t = Q.transpose(1, 2)   # [B, L, n_heads, head_dim]
+    K_t = K.transpose(1, 2)   # [B, L, n_kv_heads, head_dim]
+    V_t = V.transpose(1, 2)   # [B, L, n_kv_heads, head_dim]
+
+    Q_compact = torch.cat([Q_t[b, :real_counts[b]] for b in range(bsz)], dim=0)
+    K_compact = torch.cat([K_t[b, :real_counts[b]] for b in range(bsz)], dim=0)
+    V_compact = torch.cat([V_t[b, :real_counts[b]] for b in range(bsz)], dim=0)
+    # shapes: [total_tokens, n_heads/n_kv_heads, head_dim]
+
+    # Flash varlen — bidirectional (causal=False), no dropout during fine-tuning.
+    attn_out = flash_attn_varlen_func(
+        Q_compact,
+        K_compact,
+        V_compact,
+        cu_seqlens,
+        cu_seqlens,
+        max_seqlen,
+        max_seqlen,
+        dropout_p=0.0,
+        causal=False,
+    )  # [total_tokens, n_heads, head_dim]
+
+    # Scatter back into zero-padded [B, L, n_heads * head_dim].
+    # new_zeros preserves dtype and device from Q.
+    out_full = Q.new_zeros(bsz, q_len, n_heads * head_dim)
+    offset = 0
+    for b in range(bsz):
+        rc = real_counts[b]
+        out_full[b, :rc] = attn_out[offset:offset + rc].reshape(rc, n_heads * head_dim)
+        offset += rc
+
+    return out_full
 
 
 def A2DAttention_fast_forward(
@@ -138,17 +217,26 @@ def A2DAttention_fast_forward(
     use_varlen = seq_info is not None and past_key_values is None
 
     if use_varlen:
-        block_mask = kwargs.get("block_attention_mask", None)
-        if block_mask is not None:
-            # SDPA with pre-built bidirectional block-diagonal mask from the collator.
-            effective_mask = block_mask
-            backend = SDPA
-        else:
-            # block_attention_mask not provided (flash_attn available path):
-            # fall back to standard non-packed SDPA to avoid causal mask from
-            # build_sdpa_packed_attention_mask() and to avoid uncompacted varlen tensors.
-            effective_mask = None
-            backend = SDPA
+        seq_lengths_list = kwargs.get("seq_lengths", None)
+        if HAS_FLASH_ATTENTION and seq_lengths_list is not None:
+            # Flash varlen path: compact padding tokens out, call flash_attn_varlen_func
+            # directly (bypasses run_attention which does uncompacted reshape).
+            A = _flash_varlen_packed(
+                Q, K, V,
+                seq_lengths_list=seq_lengths_list,
+                n_heads=n_heads,
+                n_kv_heads=n_kv_heads,
+                head_dim=head_dim,
+            )
+            # _flash_varlen_packed returns [B, L, n_heads * head_dim] already
+            attn_output = self.apply_o(self, A)
+            return attn_output, None
+
+        # SDPA fallback: flash not available or seq_lengths absent.
+        # Use block_attention_mask (bidirectional block-diagonal) from collator when present.
+        # Do NOT fall back to build_sdpa_packed_attention_mask() — it builds causal blocks.
+        effective_mask = kwargs.get("block_attention_mask", None)
+        backend = SDPA
     else:
         effective_mask = attention_mask
         backend = SDPA if attention_mask is not None else select_attention_backend(False)


### PR DESCRIPTION
## Summary

Implements `_flash_varlen_packed()` helper in `unturtle/models/a2d/_fast_forward.py` to enable proper Flash varlen attention for packed sequences (Issue #22).

**Problem**: `flash_attn_varlen_func` requires padding-free Q/K/V tensors `[total_tokens, n_heads, head_dim]`, but the collator produces `[B, max_seq_length]` padded tensors. Feeding them directly caused metadata mismatch.

**Solution**: compact + scatter pattern
1. Strip padding per row using `seq_lengths_list` (from collator `seq_lengths` key)
2. Concatenate real tokens into flat `[total_tokens, ...]` buffer
3. Call `flash_attn_varlen_func(causal=False)` with sample-level `cu_seqlens`
4. Scatter output back to `[B, L, n_heads * head_dim]` with zeros at padding

`A2DAttention_fast_forward` now takes early-return when `HAS_FLASH_ATTENTION=True` and `seq_lengths` is in kwargs. Falls back to SDPA + `block_attention_mask` when flash is unavailable.

## Files Changed

| File | Change |
|------|--------|
| `unturtle/models/a2d/_fast_forward.py` | Add `_flash_varlen_packed`, update `use_varlen` branch |
| `tests/models/test_a2d.py` | Add `TestFlashVarlenCompaction` (3 tests) |

## Test plan

- [x] `python -m pytest tests/models/test_a2d.py -v` — 23/23 passed (incl. GPU bidirectionality test)
- [x] `python -m pytest tests/diffusion/ tests/models/ tests/test_fast_diffusion_model.py -q` — 158 passed, 1 pre-existing failure (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)