### PR TITLE
🐛 fix(llada): add _tied_weights_keys=[] for 4-bit quantization compat (#26)

### DIFF
--- a/unturtle/models/llada/modeling_llada.py
+++ b/unturtle/models/llada/modeling_llada.py
@@ -1466,6 +1466,9 @@ class LLaDAModelLM(LLaDAPreTrainedModel):
     base_model_prefix = "model"
     # _no_split_modules = ["LLaDABlock", "LLaDASequentialBlock", "LLaDALlamaBlock"]
     _no_split_modules = ["LLaDALlamaBlock"]
+    # Required by transformers >= 4.40 get_keys_to_not_convert() for 4-bit/8-bit loading.
+    # LLaDA has no tied weights so this is an empty list.
+    _tied_weights_keys: list[str] = []
 
     def __init__(self, config: LLaDAConfig, model: Optional[LLaDAModel] = None, init_params: bool = False):
         super().__init__(config)


### PR DESCRIPTION
## Summary

`LLaDAModelLM` did not declare `_tied_weights_keys`, causing `AttributeError` when loading with `load_in_4bit=True` on transformers >= 4.40.

## Root cause

`transformers.quantizers.base.get_keys_to_not_convert()` accesses `model.all_tied_weights_keys` (a `PreTrainedModel` property that reads `self._tied_weights_keys`). Without the class attribute, Python falls through to `__getattr__` and raises.

## Fix

Add `_tied_weights_keys: list[str] = []` to `LLaDAModelLM` — LLaDA has no tied weights.

Closes #26