### PR TITLE
🐛 fix(llada): fix 4-bit loading and real-checkpoint E2E on transformers 5.x

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,8 @@ These rules apply to `_patch_a2d_peft`, `_patch_dream_peft`, `_patch_llada_peft`
 | `build_sdpa_packed_attention_mask()` is causal | Packed SDPA silently reintroduces causal masking for dLLM | Never use the upstream `build_sdpa_packed_attention_mask()` for A2D/packed path — it builds upper-triangular causal blocks; use `block_attention_mask` from collator or `effective_mask=None` |
 | real-checkpoint tokenizer may lack `mask_token_id` | `MaskedDiffusionDataCollator` init fails even though the model supports masking | Use `tokenizer.mask_token_id or model.config.mask_token_id` and pass `mask_token_id=` explicitly in slow E2E tests |
 | prompt/full tokenization mismatch in completion-only datasets | prompt tokens become maskable or completion boundary shifts for override checkpoints | Build prompt/completion ids with the same tokenizer settings (e.g. both `add_special_tokens=False`) and concatenate them explicitly |
+| `LLaDAModelLM` lacks `all_tied_weights_keys` (Hub class) | `AttributeError: 'LLaDAModelLM' has no attribute 'all_tied_weights_keys'` during 4-bit load | `FastDiffusionModel._load_model_auto` routes `model_type="llada"` to unturtle's own class; unturtle class calls `self.post_init()` and accepts `tie_weights(**kwargs)` |
+| `load_in_4bit` without `device_map` OOM on crowded GPU | OOM caught silently → falls through to Hub class → `all_tied_weights_keys` error | `FastDiffusionModel.from_pretrained` sets `device_map="auto"` automatically when `load_in_4bit=True` |
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -701,3 +701,28 @@ input_ids = prompt_ids + completion_ids
 labels = [-100] * len(prompt_ids) + completion_ids
 ```
 
+### 13. `LLaDAModelLM` の HF 互換性: `post_init`, `tie_weights(**kwargs)`, `**kwargs` が必要
+
+transformers 5.x で BitsAndBytes 4-bit ロードをするためには `LLaDAModelLM` に以下が必要:
+
+1. **`__init__` 末尾で `self.post_init()` を呼ぶ** → `all_tied_weights_keys` を設定する (`get_keys_to_not_convert()` が参照)
+2. **`tie_weights(self, **kwargs)` を受け付ける** → transformers の `init_weights()` が `tie_weights(recompute_mapping=False)` と呼ぶため
+3. **`__init__(self, config, ..., **kwargs)` が `super().__init__(config, **kwargs)` に透過する** → BnB quantizer が config 以外のkwargを注入することがある
+
+Hub の `modeling_llada.py` は古く、これらを持たない。`FastDiffusionModel._load_model_auto` は
+`model_type="llada"` を unturtle ネイティブクラスに直接ルーティングすることで Hub コードを回避する。
+
+### 14. `load_in_4bit=True` では `device_map="auto"` が必要 (multi-GPU / GPU 0 占有時)
+
+`device_map` を省略すると 4-bit モデルが GPU 0 に全ロードされる。
+他プロセスが GPU 0 を占有していると OOM になり、ロード失敗が `except Exception` で握り潰され
+`AutoModel` フォールバックへ進む (その際 Hub の古いクラスが使われてさらに失敗)。
+
+`FastDiffusionModel.from_pretrained` は `load_in_4bit=True` 時に自動で `device_map="auto"` を設定する:
+```python
+if load_in_4bit and not is_on_cpu:
+    load_kwargs["quantization_config"] = bnb_config
+    if "device_map" not in load_kwargs:
+        load_kwargs["device_map"] = "auto"
+```
+

--- a/tests/test_e2e_real_checkpoint.py
+++ b/tests/test_e2e_real_checkpoint.py
@@ -173,7 +173,7 @@ class TestPeftAndTraining:
             per_device_train_batch_size=2,
             logging_steps=1,
             save_steps=100,
-            fp16=True,
+            bf16=True,
             dataloader_drop_last=True,
             remove_unused_columns=False,
             report_to="none",
@@ -182,10 +182,10 @@ class TestPeftAndTraining:
         losses: list[float] = []
         original_log = DiffusionTrainer.log
 
-        def _capturing_log(self_inner, logs, **kw):
+        def _capturing_log(self_inner, logs, *args, **kw):
             if "loss" in logs:
                 losses.append(float(logs["loss"]))
-            original_log(self_inner, logs, **kw)
+            original_log(self_inner, logs, *args, **kw)
 
         DiffusionTrainer.log = _capturing_log
         try:

--- a/unturtle/fast_diffusion_model.py
+++ b/unturtle/fast_diffusion_model.py
@@ -405,10 +405,49 @@ def _load_model_auto(model_name: str, load_kwargs: dict, trust_remote_code: bool
 
     Registers unturtle model types so AutoConfig resolves them before trying.
     Falls back through the chain and raises if all attempts fail.
-    """
-    import unturtle.models  # noqa: F401 — registers A2D AutoConfig entries
 
-    from transformers import AutoModel, AutoModelForCausalLM, AutoModelForMaskedLM
+    Strategy: peek at the model_type in AutoConfig, and if it matches an unturtle
+    native class (llada, dream, a2d_*), use that class directly — bypassing
+    trust_remote_code so the Hub's potentially older modeling code is never loaded.
+    This ensures fixes in unturtle model classes (e.g. _tied_weights_keys) take effect.
+    """
+    import unturtle.models  # noqa: F401 — registers A2D/LLaDA/Dream AutoConfig entries
+
+    from transformers import AutoConfig, AutoModel, AutoModelForCausalLM, AutoModelForMaskedLM
+
+    # Map model_type → unturtle model class (bypasses trust_remote_code Hub code).
+    _UNTURTLE_MODEL_CLASSES: dict[str, Any] = {}
+    try:
+        from unturtle.models.llada import LLaDAModelLM
+        _UNTURTLE_MODEL_CLASSES["llada"] = LLaDAModelLM
+    except ImportError:
+        pass
+    try:
+        from unturtle.models.dream import DreamModel
+        _UNTURTLE_MODEL_CLASSES["dream"] = DreamModel
+    except ImportError:
+        pass
+
+    # Peek at model_type without loading weights.
+    try:
+        peek_kwargs: dict[str, Any] = {}
+        if "token" in load_kwargs:
+            peek_kwargs["token"] = load_kwargs["token"]
+        config = AutoConfig.from_pretrained(
+            model_name, trust_remote_code=trust_remote_code, **peek_kwargs
+        )
+        model_type = getattr(config, "model_type", "")
+        if model_type in _UNTURTLE_MODEL_CLASSES:
+            native_cls = _UNTURTLE_MODEL_CLASSES[model_type]
+            _logger.debug(
+                "FastDiffusionModel: using native unturtle class %s for model_type=%r",
+                native_cls.__name__, model_type,
+            )
+            return native_cls.from_pretrained(model_name, **load_kwargs)
+    except torch.cuda.OutOfMemoryError:
+        raise  # OOM should propagate, not fall through to slower AutoModel loaders
+    except Exception as exc:  # noqa: BLE001
+        _logger.debug("FastDiffusionModel: native class lookup failed: %s", exc)
 
     loaders = [
         ("AutoModel", AutoModel),
@@ -565,6 +604,9 @@ class FastDiffusionModel:
                     bnb_4bit_use_double_quant=True,
                 )
                 load_kwargs["quantization_config"] = bnb_config
+                # device_map="auto" is required for multi-GPU or when GPU 0 is partially occupied.
+                if "device_map" not in load_kwargs:
+                    load_kwargs["device_map"] = "auto"
             except ImportError:
                 _warn_once(
                     "bitsandbytes not installed — falling back to full-precision loading."

--- a/unturtle/models/llada/modeling_llada.py
+++ b/unturtle/models/llada/modeling_llada.py
@@ -1053,6 +1053,10 @@ class LLaDAPreTrainedModel(PreTrainedModel):
         hf_config = config
         if not hasattr(hf_config, "to_dict"):
             hf_config = LLaDAConfig(**config.__dict__)
+        # Strip quantization-related kwargs that transformers may inject (e.g. load_in_4bit).
+        # PreTrainedModel.__init__ does not accept them directly.
+        for _k in ("load_in_4bit", "load_in_8bit", "quantization_config"):
+            model_kwargs.pop(_k, None)
         super().__init__(hf_config, *model_args, **model_kwargs)
 
     def _init_weights(self, module):
@@ -1470,8 +1474,8 @@ class LLaDAModelLM(LLaDAPreTrainedModel):
     # LLaDA has no tied weights so this is an empty list.
     _tied_weights_keys: list[str] = []
 
-    def __init__(self, config: LLaDAConfig, model: Optional[LLaDAModel] = None, init_params: bool = False):
-        super().__init__(config)
+    def __init__(self, config: LLaDAConfig, model: Optional[LLaDAModel] = None, init_params: bool = False, **kwargs):
+        super().__init__(config, **kwargs)
 
         if not model:
             model_config = create_model_config_from_pretrained_config(config)
@@ -1480,6 +1484,8 @@ class LLaDAModelLM(LLaDAPreTrainedModel):
             self.model = LLaDAModel(model_config, init_params=init_params)
         else:
             self.model = model
+        # Required by transformers >= 4.40: sets self.all_tied_weights_keys used by quantizers.
+        self.post_init()
 
     def forward(
         self,
@@ -1574,6 +1580,6 @@ class LLaDAModelLM(LLaDAPreTrainedModel):
         else:
             self.model.transformer.ff_out = value
 
-    def tie_weights(self):
+    def tie_weights(self, **kwargs):
         if self.config.weight_tying:
             self.model.transformer.ff_out = self.model.transformer.wte


### PR DESCRIPTION
## Summary

- **`LLaDAModelLM`** was missing `self.post_init()` at end of `__init__` → `all_tied_weights_keys` never set → `AttributeError` during `get_keys_to_not_convert()` in BnB 4-bit loader (transformers ≥5.0)
- **`LLaDAModelLM.tie_weights`** didn't accept `**kwargs` → `TypeError` when transformers 5.x calls `tie_weights(recompute_mapping=False)` from `init_weights()`
- **`FastDiffusionModel.from_pretrained`** omitted `device_map="auto"` for 4-bit loads → OOM on crowded GPU 0 was silently swallowed → fell through to Hub's old `LLaDAModelLM` → surfaced as misleading `all_tied_weights_keys` error

## Fixes

| File | Change |
|------|--------|
| `unturtle/models/llada/modeling_llada.py` | `LLaDAModelLM.__init__`: add `**kwargs` + `self.post_init()`; `LLaDAPreTrainedModel.__init__`: strip BnB kwargs before super(); `tie_weights`: accept `**kwargs` |
| `unturtle/fast_diffusion_model.py` | Re-raise `OutOfMemoryError` (don't swallow); set `device_map="auto"` automatically when `load_in_4bit=True` |
| `tests/test_e2e_real_checkpoint.py` | Use `bf16=True` (not `fp16`) for bfloat16 model; fix `_capturing_log` to accept `*args` for newer trainer.log signature |
| `CLAUDE.md` / `AGENTS.md` | Document new gotchas §13 and §14 |

## Test plan

- [x] All 4 slow E2E tests pass on Blackwell GPU (GSAI-ML/LLaDA-8B-Instruct, 4-bit):
  ```
  pytest tests/test_e2e_real_checkpoint.py -m slow -v
  # 4 passed in 573s
  ```
- [x] All 171 fast unit/integration tests unaffected:
  ```
  pytest tests/diffusion/ tests/models/ tests/test_fast_diffusion_model.py tests/test_e2e_integration.py -q
  # 171 passed, 1 skipped
  ```