### PR TITLE
🐛 fix: transformers 5.x API compatibility (compute_loss, tie_weights, attention signature)

### DIFF
--- a/unturtle/diffusion/trainer.py
+++ b/unturtle/diffusion/trainer.py
@@ -187,6 +187,13 @@ class DiffusionTrainer(UnslothTrainer):
             loss_weights=loss_weights,
         )
 
+        # When num_items_in_batch is provided, normalize loss by it so that
+        # transformers' training_step does not also divide by gradient_accumulation_steps.
+        # (transformers 5.x training_step skips the /grad_accum normalization when
+        # compute_loss receives num_items_in_batch and num_items_in_batch is not None.)
+        if num_items_in_batch is not None:
+            loss = loss / num_items_in_batch
+
         return (loss, outputs) if return_outputs else loss
 
     # ------------------------------------------------------------------ #

--- a/unturtle/diffusion/trainer.py
+++ b/unturtle/diffusion/trainer.py
@@ -160,6 +160,7 @@ class DiffusionTrainer(UnslothTrainer):
         model: torch.nn.Module,
         inputs: dict[str, torch.Tensor | Any],
         return_outputs: bool = False,
+        num_items_in_batch: torch.Tensor | int | None = None,
         **kwargs: Any,
     ) -> torch.Tensor | tuple[torch.Tensor, Any]:
         """Compute the masked diffusion CE loss using the Triton kernel.

--- a/unturtle/models/a2d/_fast_forward.py
+++ b/unturtle/models/a2d/_fast_forward.py
@@ -151,12 +151,9 @@ def _flash_varlen_packed(
 def A2DAttention_fast_forward(
     self,
     hidden_states: torch.Tensor,
-    attention_mask: Optional[torch.Tensor] = None,
-    position_ids: Optional[torch.LongTensor] = None,
-    past_key_values: Optional[Cache] = None,
-    use_cache: Optional[bool] = False,
-    cache_position: Optional[torch.LongTensor] = None,
     position_embeddings: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+    attention_mask: Optional[torch.Tensor] = None,
+    past_key_values: Optional[Cache] = None,
     **kwargs,
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
     """Bidirectional (non-causal) fast forward for A2D attention layers.
@@ -165,6 +162,12 @@ def A2DAttention_fast_forward(
     unsloth's Triton-fused LoRA kernels when they are patched in.
     Attention is fully bidirectional (``causal=False``).
     """
+    # Extract position_ids and cache_position from kwargs.
+    # transformers 5.x LlamaDecoderLayer passes them as named keyword args to
+    # self.self_attn(), which lands in **kwargs here since LlamaAttention.forward
+    # no longer declares them as explicit parameters.
+    position_ids: Optional[torch.LongTensor] = kwargs.get("position_ids", None)
+    cache_position: Optional[torch.LongTensor] = kwargs.get("cache_position", None)
     bsz, q_len, _ = hidden_states.size()
 
     n_heads = self.config.num_attention_heads

--- a/unturtle/models/llada/modeling_llada.py
+++ b/unturtle/models/llada/modeling_llada.py
@@ -1590,3 +1590,6 @@ class LLaDAModelLM(LLaDAPreTrainedModel):
     def tie_weights(self, **kwargs):
         if self.config.weight_tying:
             self.model.transformer.ff_out = self.model.transformer.wte
+        # Always call super() so transformers 5.x can run its recompute_mapping logic.
+        # This handles missing_keys and recompute_mapping kwargs passed by from_pretrained.
+        super().tie_weights(**kwargs)


### PR DESCRIPTION
## Summary

Three API compatibility fixes found by the issue #31 audit:

- **#38** `DiffusionTrainer.compute_loss`: add `num_items_in_batch` as explicit parameter — transformers 5.x `training_step` passes it for gradient accumulation scaling; previously silently absorbed by `**kwargs`
- **#40** `LLaDAModelLM.tie_weights`: call `super().tie_weights(**kwargs)` — transformers 5.x `from_pretrained` passes `missing_keys` and `recompute_mapping=False`; previously kwargs absorbed them without propagating to parent
- **#39** `A2DAttention_fast_forward`: align signature with transformers 5.x `LlamaAttention.forward` — remove explicit `position_ids`, `use_cache`, `cache_position` params; extract `position_ids` and `cache_position` from `**kwargs` in body instead

Closes #38, #39, #40

## Test plan

- [x] `python -m pytest tests/diffusion/ tests/models/ tests/test_fast_diffusion_model.py tests/test_e2e_integration.py -m "not slow" -q` — 171 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)