### PR TITLE
🐛 fix(kernel): normalize loss by n_maskable to match MDLM/d1 reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -744,22 +744,24 @@ if load_in_4bit and not is_on_cpu:
         load_kwargs["device_map"] = "auto"
 ```
 
-### 15. 損失の正規化分母: unturtle は `n_masked`、MDLM 参照実装は `n_maskable`
+### 15. 損失の正規化分母: `n_maskable` (MDLM/d1 参照実装に合わせる)
 
-`fused_masked_diffusion_loss` は損失を **実際にマスクされたトークン数 (`n_masked`)** で正規化する。
-MDLM 参照実装 (`dev/repos/dllm/dllm/core/trainers/mdlm.py`, `loss_norm_type="token"`) は
-**マスク可能なトークン数 (`n_maskable = labels != -100` の合計)** で正規化する。
+`fused_masked_diffusion_loss` は損失を **マスク可能なトークン数 (`n_maskable = labels != -100`)** で正規化する。
+これは MDLM 参照実装および d1 SFT と一致する。
 
 ```python
-# unturtle (fused_masked_diffusion_loss.py)
-n_masked = diffusion_mask.sum().clamp_min(1)   # 実際にマスクされたトークン
-loss = per_token_loss.sum() / n_masked
+# unturtle (fused_masked_diffusion_loss.py) — MDLM/d1 に合わせた実装
+n_maskable = (flat_labels != -100).sum().clamp_min(1)
+loss = per_token_loss.sum() / n_maskable
 
 # MDLM reference (mdlm.py L202)
-token_nll /= maskable_mask.sum().clamp_min(1)  # マスク可能なトークン (labels != -100)
+token_nll /= maskable_mask.sum().clamp_min(1)  # maskable_mask = labels != -100
+
+# d1 SFT reference (sft_trainer.py L25)
+loss = loss.sum() / (inputs["input_ids"].numel() - num_prompt_tokens)
 ```
 
-**設計意図**: `n_masked` で正規化すると mask_rate が変化しても損失スケールが安定し、
-learning rate のチューニングが容易になる。ただし低 mask_rate のとき MDLM 参照より損失値が
-数値的に大きくなる。LR を MDLM 参照実装から直接移植する場合は注意。
+**注意**: 以前は `n_masked = diffusion_mask.sum()` (実際にマスクされたトークン数) で割っていた。
+mask_rate=0.15 のとき旧実装は MDLM より約 6.7 倍大きい loss 値を出していた。
+`n_maskable` に変更したことで LR を参照実装からそのまま移植できるようになった。
 

--- a/tests/diffusion/test_gpu_accuracy.py
+++ b/tests/diffusion/test_gpu_accuracy.py
@@ -51,14 +51,15 @@ def _reference_loss(
         reduction="none",
     ).view(B, L)
 
-    n_masked = diffusion_mask.sum().clamp_min(1)
+    # Normalize by n_maskable (labels != -100), matching MDLM/d1 reference.
+    n_maskable = (labels != -100).sum().clamp_min(1)
 
     if loss_weights is None:
-        return per_token.sum() / n_masked
+        return per_token.sum() / n_maskable
 
     if loss_weights.shape == (B,):
         loss_weights = loss_weights.unsqueeze(1)
-    return (per_token * loss_weights).sum() / n_masked
+    return (per_token * loss_weights).sum() / n_maskable
 
 
 # ---------------------------------------------------------------------------

--- a/tests/diffusion/test_masked_diffusion_loss.py
+++ b/tests/diffusion/test_masked_diffusion_loss.py
@@ -28,7 +28,11 @@ def _reference_masked_ce(
     diffusion_mask: torch.Tensor,
     loss_weights: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    """Pure-PyTorch reference implementation."""
+    """Pure-PyTorch reference implementation.
+
+    Normalizes by n_maskable = (labels != -100).sum(), matching the MDLM reference
+    (dev/repos/dllm/dllm/core/trainers/mdlm.py L202) and d1 SFT reference.
+    """
     B, L, V = logits.shape
     masked_labels = labels.clone()
     masked_labels[~diffusion_mask] = -100
@@ -40,15 +44,16 @@ def _reference_masked_ce(
         reduction="none",
     ).view(B, L)  # 0 at unmasked positions
 
-    n_masked = diffusion_mask.sum().clamp_min(1)
+    # Normalize by maskable tokens (labels != -100), not by actually masked tokens.
+    n_maskable = (labels != -100).sum().clamp_min(1)
 
     if loss_weights is None:
-        return per_token.sum() / n_masked
+        return per_token.sum() / n_maskable
 
     if loss_weights.dim() == 1:
         loss_weights = loss_weights.unsqueeze(1)
 
-    return (per_token * loss_weights).sum() / n_masked
+    return (per_token * loss_weights).sum() / n_maskable
 
 
 # ---------------------------------------------------------------------------

--- a/unturtle/kernels/fused_masked_diffusion_loss.py
+++ b/unturtle/kernels/fused_masked_diffusion_loss.py
@@ -110,18 +110,19 @@ def fused_masked_diffusion_loss(
             reduction="none",
         ).float()  # [B*L]
 
-    # Normalize by the number of *actually masked* tokens (n_masked), not maskable tokens (n_maskable).
-    # MDLM reference (dev/repos/dllm/dllm/core/trainers/mdlm.py, loss_norm_type="token") normalizes
-    # by maskable_mask.sum() (i.e. labels != -100). unturtle normalizes by diffusion_mask.sum()
-    # (tokens that were masked for this training step).
+    # Normalize by n_maskable = number of tokens eligible for masking (labels != -100).
+    # This matches the MDLM reference (dev/repos/dllm/dllm/core/trainers/mdlm.py L202:
+    #   token_nll /= maskable_mask.sum().clamp_min(1)  # maskable_mask = labels != -100)
+    # and d1 SFT (sft_trainer.py L25: loss / (numel - num_prompt_tokens)).
     #
-    # Design rationale: normalizing by n_masked makes the loss scale consistent regardless of
-    # mask_rate, which simplifies hyperparameter tuning when mask_rate varies during training.
-    # Trade-off: at low mask rates the loss is numerically larger than the MDLM reference.
-    n_masked = diffusion_mask.sum().clamp_min(1)
+    # Using n_maskable (rather than n_masked = diffusion_mask.sum()) keeps the loss scale
+    # consistent with reference implementations so that learning rates transfer directly.
+    # At mask_rate=0.15, n_masked ≈ 0.15 * n_maskable, so the previous n_masked denominator
+    # produced ~6.7x larger loss values than MDLM for the same data.
+    n_maskable = (flat_labels != -100).sum().clamp_min(1)
 
     if loss_weights is None:
-        return per_token_loss.sum() / n_masked
+        return per_token_loss.sum() / n_maskable
 
     per_token_loss = per_token_loss.view(B, L)
 
@@ -133,4 +134,4 @@ def fused_masked_diffusion_loss(
     )
 
     weighted = per_token_loss * loss_weights.to(per_token_loss.dtype)
-    return weighted.sum() / n_masked
+    return weighted.sum() / n_maskable


### PR DESCRIPTION
## Summary

Fixes issue #34: switch loss denominator from `n_masked` to `n_maskable`.

| | Previous (unturtle) | MDLM reference | d1 SFT reference |
|---|---|---|---|
| Denominator | `diffusion_mask.sum()` (actually masked tokens) | `(labels != -100).sum()` | `numel - num_prompt_tokens` |

At mask_rate=0.15, the previous denominator produced ~6.7x larger loss values than MDLM for the same data, making learning rate transfer from reference implementations impossible.

## Changes

- `unturtle/kernels/fused_masked_diffusion_loss.py`: `n_masked` → `n_maskable = (flat_labels != -100).sum()`
- `tests/diffusion/test_masked_diffusion_loss.py`: update `_reference_masked_ce` to match
- `tests/diffusion/test_gpu_accuracy.py`: update `_reference_loss` to match
- `CLAUDE.md §15`: update to reflect the new design decision

Closes #34

## Test plan

- [x] `python -m pytest tests/diffusion/ tests/models/ tests/test_fast_diffusion_model.py tests/test_e2e_integration.py -m "not slow" -q` — 171 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)