### PR TITLE
✨ feat(model): add FastDiffusionModel.for_inference / for_training / save_pretrained_merged (#45)

### DIFF
--- a/tests/test_fast_diffusion_model.py
+++ b/tests/test_fast_diffusion_model.py
@@ -23,6 +23,8 @@ Tests cover:
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import pytest
 import torch
 
@@ -750,6 +752,48 @@ class TestInferenceTrainingMethods:
         with FastDiffusionModel.inference_context(tiny_model):
             assert not torch.is_grad_enabled()
 
+    def test_inference_context_restores_gc_mode_false(self, tiny_model):
+        """inference_context should restore False GC mode exactly."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        tiny_model._unturtle_gradient_checkpointing_mode = False
+        tiny_model.train()
+        with FastDiffusionModel.inference_context(tiny_model):
+            assert _all_gc_flags_false(tiny_model)
+        assert tiny_model.training
+        assert tiny_model._unturtle_gradient_checkpointing_mode is False
+        assert _all_gc_flags_false(tiny_model)
+
+    def test_inference_context_restores_gc_mode_unsloth(self, tiny_model):
+        """inference_context should preserve the symbolic 'unsloth' mode."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        FastDiffusionModel.for_training(tiny_model, use_gradient_checkpointing="unsloth")
+        with FastDiffusionModel.inference_context(tiny_model):
+            assert _all_gc_flags_false(tiny_model)
+        assert tiny_model._unturtle_gradient_checkpointing_mode == "unsloth"
+        assert _all_gc_flags_true(tiny_model)
+
+    def test_inference_context_restores_state_on_exception(self, tiny_model):
+        """inference_context should restore mode/state even if body raises."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        FastDiffusionModel.for_training(tiny_model, use_gradient_checkpointing=False)
+        with pytest.raises(RuntimeError, match="boom"):
+            with FastDiffusionModel.inference_context(tiny_model):
+                raise RuntimeError("boom")
+        assert tiny_model.training
+        assert tiny_model._unturtle_gradient_checkpointing_mode is False
+        assert _all_gc_flags_false(tiny_model)
+
+    def test_for_training_preserves_requested_unsloth_mode(self, tiny_model):
+        """for_training should remember symbolic unsloth mode for later restore."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        FastDiffusionModel.for_training(tiny_model, use_gradient_checkpointing="unsloth")
+        assert tiny_model._unturtle_gradient_checkpointing_mode == "unsloth"
+        assert _all_gc_flags_true(tiny_model)
+
 
 # ---------------------------------------------------------------------------
 # TestSavePretrainedMerged — save_pretrained_merged
@@ -785,14 +829,28 @@ class TestSavePretrainedMerged:
         assert len(files) >= 2
 
     def test_save_does_not_modify_original(self, peft_model, tmp_path):
-        """save_pretrained_merged leaves the original PEFT model intact."""
+        """save_pretrained_merged leaves adapter weights on the original model intact."""
         from peft import PeftModel
         from unturtle.fast_diffusion_model import FastDiffusionModel
 
+        adapter_weights_before = {
+            name: param.detach().clone()
+            for name, param in peft_model.named_parameters()
+            if "lora_" in name
+        }
+
         save_dir = tmp_path / "merged2"
         FastDiffusionModel.save_pretrained_merged(peft_model, str(save_dir))
-        # Original model should still be a PeftModel
+
         assert isinstance(peft_model, PeftModel)
+        adapter_weights_after = {
+            name: param.detach().clone()
+            for name, param in peft_model.named_parameters()
+            if "lora_" in name
+        }
+        assert adapter_weights_before.keys() == adapter_weights_after.keys()
+        for name in adapter_weights_before:
+            assert torch.equal(adapter_weights_before[name], adapter_weights_after[name])
 
     def test_save_with_tokenizer(self, peft_model, tmp_path):
         """save_pretrained_merged saves tokenizer when provided."""
@@ -805,3 +863,76 @@ class TestSavePretrainedMerged:
             peft_model, str(save_dir), tokenizer=mock_tokenizer
         )
         mock_tokenizer.save_pretrained.assert_called_once_with(str(save_dir))
+
+
+class TestPushToHubMerged:
+    """Tests for FastDiffusionModel.push_to_hub_merged."""
+
+    @pytest.fixture
+    def peft_model(self, tiny_model):
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        return FastDiffusionModel.get_peft_model(
+            tiny_model,
+            r=4,
+            target_modules=["q_proj", "k_proj", "v_proj", "o_proj"],
+            lora_alpha=4,
+            lora_dropout=0,
+            use_gradient_checkpointing=False,
+        )
+
+    def test_push_forwards_kwargs_to_model_and_tokenizer(self, peft_model, monkeypatch):
+        """push_to_hub_merged should forward the same Hub kwargs to tokenizer."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        pushed = {}
+
+        def fake_deepcopy(obj):
+            merged = MagicMock()
+            merged_base = MagicMock()
+            merged.merge_and_unload.return_value = merged_base
+            pushed["merged_base"] = merged_base
+            return merged
+
+        monkeypatch.setattr("copy.deepcopy", fake_deepcopy)
+
+        tokenizer = MagicMock()
+        FastDiffusionModel.push_to_hub_merged(
+            peft_model,
+            "user/repo",
+            tokenizer=tokenizer,
+            token="hf_xxx",
+            revision="main",
+            private=True,
+            create_pr=True,
+            commit_message="test commit",
+        )
+
+        pushed["merged_base"].push_to_hub.assert_called_once_with(
+            "user/repo",
+            safe_serialization=True,
+            token="hf_xxx",
+            revision="main",
+            private=True,
+            create_pr=True,
+            commit_message="test commit",
+        )
+        tokenizer.push_to_hub.assert_called_once_with(
+            "user/repo",
+            safe_serialization=True,
+            token="hf_xxx",
+            revision="main",
+            private=True,
+            create_pr=True,
+            commit_message="test commit",
+        )
+
+
+def _all_gc_flags_false(model):
+    flags = [m.gradient_checkpointing for m in model.modules() if hasattr(m, "gradient_checkpointing")]
+    return all(flag is False for flag in flags)
+
+
+def _all_gc_flags_true(model):
+    flags = [m.gradient_checkpointing for m in model.modules() if hasattr(m, "gradient_checkpointing")]
+    return all(flag is True for flag in flags)

--- a/tests/test_fast_diffusion_model.py
+++ b/tests/test_fast_diffusion_model.py
@@ -682,3 +682,126 @@ class TestLLaDAPatching:
         with torch.no_grad():
             out = peft_model(input_ids=input_ids)
         assert out.logits.shape == (B, L, tiny_llada_model.config.vocab_size)
+
+
+# ---------------------------------------------------------------------------
+# TestInferenceTrainingMethods — for_inference / for_training / inference_context
+# ---------------------------------------------------------------------------
+
+
+class TestInferenceTrainingMethods:
+    """Tests for FastDiffusionModel.for_inference, for_training, inference_context."""
+
+    def test_for_inference_sets_eval(self, tiny_model):
+        """for_inference puts model in eval mode."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        tiny_model.train()
+        assert tiny_model.training
+        FastDiffusionModel.for_inference(tiny_model)
+        assert not tiny_model.training
+
+    def test_for_inference_returns_model(self, tiny_model):
+        """for_inference returns the same model object."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        returned = FastDiffusionModel.for_inference(tiny_model)
+        assert returned is tiny_model
+
+    def test_for_training_sets_train(self, tiny_model):
+        """for_training puts model in training mode."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        tiny_model.eval()
+        assert not tiny_model.training
+        FastDiffusionModel.for_training(tiny_model, use_gradient_checkpointing=False)
+        assert tiny_model.training
+
+    def test_for_training_returns_model(self, tiny_model):
+        """for_training returns the same model object."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        returned = FastDiffusionModel.for_training(tiny_model, use_gradient_checkpointing=False)
+        assert returned is tiny_model
+
+    def test_inference_context_restores_train_mode(self, tiny_model):
+        """inference_context restores training mode on exit."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        tiny_model.train()
+        with FastDiffusionModel.inference_context(tiny_model):
+            assert not tiny_model.training  # eval inside context
+        assert tiny_model.training  # restored after exit
+
+    def test_inference_context_stays_eval_if_was_eval(self, tiny_model):
+        """inference_context does not flip to train if model was already in eval."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        tiny_model.eval()
+        with FastDiffusionModel.inference_context(tiny_model):
+            assert not tiny_model.training
+        assert not tiny_model.training  # stays eval
+
+    def test_inference_context_no_grad(self, tiny_model):
+        """Inside inference_context, gradients are disabled."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        tiny_model.eval()
+        with FastDiffusionModel.inference_context(tiny_model):
+            assert not torch.is_grad_enabled()
+
+
+# ---------------------------------------------------------------------------
+# TestSavePretrainedMerged — save_pretrained_merged
+# ---------------------------------------------------------------------------
+
+
+class TestSavePretrainedMerged:
+    """Tests for FastDiffusionModel.save_pretrained_merged."""
+
+    @pytest.fixture
+    def peft_model(self, tiny_model):
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        return FastDiffusionModel.get_peft_model(
+            tiny_model,
+            r=4,
+            target_modules=["q_proj", "k_proj", "v_proj", "o_proj"],
+            lora_alpha=4,
+            lora_dropout=0,
+            use_gradient_checkpointing=False,
+        )
+
+    def test_save_creates_directory(self, peft_model, tmp_path):
+        """save_pretrained_merged writes files to the given directory."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        save_dir = tmp_path / "merged"
+        FastDiffusionModel.save_pretrained_merged(peft_model, str(save_dir))
+        # Should contain at least a config and a weight file
+        assert save_dir.exists()
+        assert (save_dir / "config.json").exists()
+        files = list(save_dir.iterdir())
+        assert len(files) >= 2
+
+    def test_save_does_not_modify_original(self, peft_model, tmp_path):
+        """save_pretrained_merged leaves the original PEFT model intact."""
+        from peft import PeftModel
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        save_dir = tmp_path / "merged2"
+        FastDiffusionModel.save_pretrained_merged(peft_model, str(save_dir))
+        # Original model should still be a PeftModel
+        assert isinstance(peft_model, PeftModel)
+
+    def test_save_with_tokenizer(self, peft_model, tmp_path):
+        """save_pretrained_merged saves tokenizer when provided."""
+        from unittest.mock import MagicMock
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        mock_tokenizer = MagicMock()
+        save_dir = tmp_path / "merged3"
+        FastDiffusionModel.save_pretrained_merged(
+            peft_model, str(save_dir), tokenizer=mock_tokenizer
+        )
+        mock_tokenizer.save_pretrained.assert_called_once_with(str(save_dir))

--- a/unturtle/fast_diffusion_model.py
+++ b/unturtle/fast_diffusion_model.py
@@ -706,6 +706,7 @@ class FastDiffusionModel:
             use_reentrant=True,
         )
         model = get_peft_model(model, lora_config)
+        model._unturtle_gradient_checkpointing_mode = use_gradient_checkpointing
 
         FastDiffusionModel.patch_peft_model(model, lora_dropout=lora_dropout, bias=bias)
         patch_saving_functions(model)
@@ -791,9 +792,7 @@ class FastDiffusionModel:
             The same model in eval mode.
         """
         model.eval()
-        # Disable gradient checkpointing if it was enabled during training.
-        if hasattr(model, "gradient_checkpointing_disable"):
-            model.gradient_checkpointing_disable()
+        _apply_gradient_checkpointing_mode(model, False)
         return model
 
     @staticmethod
@@ -809,16 +808,7 @@ class FastDiffusionModel:
             The same model in train mode.
         """
         model.train()
-        if use_gradient_checkpointing and hasattr(model, "gradient_checkpointing_enable"):
-            try:
-                if use_gradient_checkpointing == "unsloth":
-                    # Use unsloth-style GC when available (offloads activations to CPU).
-                    from unsloth.models._utils import patch_unsloth_gradient_checkpointing  # TODO(Phase Z)
-                    patch_unsloth_gradient_checkpointing(model)
-                else:
-                    model.gradient_checkpointing_enable()
-            except Exception:  # noqa: BLE001
-                model.gradient_checkpointing_enable()
+        _apply_gradient_checkpointing_mode(model, use_gradient_checkpointing)
         return model
 
     @staticmethod
@@ -893,10 +883,7 @@ class FastDiffusionModel:
         merged.push_to_hub(repo_id, **push_kwargs)
         _logger.info("FastDiffusionModel: merged model pushed to %r", repo_id)
         if tokenizer is not None:
-            tok_kwargs: dict[str, Any] = {}
-            if token is not None:
-                tok_kwargs["token"] = token
-            tokenizer.push_to_hub(repo_id, **tok_kwargs)
+            tokenizer.push_to_hub(repo_id, **push_kwargs)
 
     @staticmethod
     @contextlib.contextmanager
@@ -914,13 +901,17 @@ class FastDiffusionModel:
             model: A dLLM model (plain or PEFT-wrapped).
         """
         was_training = model.training
+        gc_mode = _get_gradient_checkpointing_mode(model)
         FastDiffusionModel.for_inference(model)
         try:
             with torch.no_grad():
                 yield model
         finally:
             if was_training:
-                FastDiffusionModel.for_training(model)
+                FastDiffusionModel.for_training(model, use_gradient_checkpointing=gc_mode)
+            else:
+                model.eval()
+                _apply_gradient_checkpointing_mode(model, gc_mode)
 
 
 # ---------------------------------------------------------------------------
@@ -949,3 +940,36 @@ def _install_apply_stubs(model: Any) -> None:
                 module.apply_qkv = _original_apply_qkv
             if not hasattr(module, "apply_o"):
                 module.apply_o = _original_apply_o
+
+
+def _get_gradient_checkpointing_mode(model: Any) -> bool | str:
+    """Return the current gradient-checkpointing mode tracked by unturtle.
+
+    We explicitly track the requested mode because a temporary inference pass
+    should be reversible: `True`, `False`, and `"unsloth"` need to round-trip.
+    Falling back to module flags loses the distinction between `True` and
+    `"unsloth"`.
+    """
+    if hasattr(model, "_unturtle_gradient_checkpointing_mode"):
+        return model._unturtle_gradient_checkpointing_mode
+
+    for module in model.modules():
+        if hasattr(module, "gradient_checkpointing"):
+            return bool(module.gradient_checkpointing)
+    return False
+
+
+def _apply_gradient_checkpointing_mode(model: Any, mode: bool | str) -> None:
+    """Apply and persist a gradient-checkpointing mode to all reachable modules."""
+    model._unturtle_gradient_checkpointing_mode = mode
+
+    for module in model.modules():
+        if hasattr(module, "gradient_checkpointing"):
+            module.gradient_checkpointing = bool(mode)
+
+    if bool(mode):
+        if hasattr(model, "gradient_checkpointing_enable"):
+            model.gradient_checkpointing_enable()
+    else:
+        if hasattr(model, "gradient_checkpointing_disable"):
+            model.gradient_checkpointing_disable()

--- a/unturtle/fast_diffusion_model.py
+++ b/unturtle/fast_diffusion_model.py
@@ -36,10 +36,17 @@ Usage::
                         "gate_proj", "up_proj", "down_proj"],
         lora_alpha=16,
     )
+
+    # Switch to inference mode (eval + no_grad context manager)
+    FastDiffusionModel.for_inference(model)
+
+    # Save LoRA-merged weights
+    FastDiffusionModel.save_pretrained_merged(model, "output/merged", tokenizer)
 """
 
 from __future__ import annotations
 
+import contextlib
 import functools
 import logging
 import types
@@ -760,6 +767,160 @@ class FastDiffusionModel:
         # Propagate max_seq_length through the wrapped model hierarchy
         if hasattr(model, "max_seq_length"):
             _propagate_max_seq_length(model, model.max_seq_length)
+
+    @staticmethod
+    def for_inference(model: Any) -> Any:
+        """Switch model to inference mode.
+
+        Sets ``model.eval()`` and disables gradient checkpointing so that
+        inference is as fast as possible.  Returns the model for convenience.
+
+        Note: dLLMs do not use KV cache, so there is no cache-enabling step
+        unlike ``FastLanguageModel.for_inference`` for AR models.
+
+        Usage::
+
+            FastDiffusionModel.for_inference(model)
+            with torch.no_grad():
+                logits = model(**inputs).logits
+
+        Args:
+            model: A dLLM model (plain or PEFT-wrapped).
+
+        Returns:
+            The same model in eval mode.
+        """
+        model.eval()
+        # Disable gradient checkpointing if it was enabled during training.
+        if hasattr(model, "gradient_checkpointing_disable"):
+            model.gradient_checkpointing_disable()
+        return model
+
+    @staticmethod
+    def for_training(model: Any, use_gradient_checkpointing: bool | str = True) -> Any:
+        """Switch model back to training mode and re-enable gradient checkpointing.
+
+        Args:
+            model:                      A dLLM model (plain or PEFT-wrapped).
+            use_gradient_checkpointing: ``True`` / ``"unsloth"`` to enable GC,
+                                        ``False`` to leave it disabled.
+
+        Returns:
+            The same model in train mode.
+        """
+        model.train()
+        if use_gradient_checkpointing and hasattr(model, "gradient_checkpointing_enable"):
+            try:
+                if use_gradient_checkpointing == "unsloth":
+                    # Use unsloth-style GC when available (offloads activations to CPU).
+                    from unsloth.models._utils import patch_unsloth_gradient_checkpointing  # TODO(Phase Z)
+                    patch_unsloth_gradient_checkpointing(model)
+                else:
+                    model.gradient_checkpointing_enable()
+            except Exception:  # noqa: BLE001
+                model.gradient_checkpointing_enable()
+        return model
+
+    @staticmethod
+    def save_pretrained_merged(
+        model: Any,
+        save_directory: str,
+        tokenizer: Any = None,
+        safe_serialization: bool = True,
+        **kwargs: Any,
+    ) -> None:
+        """Merge LoRA adapters into the base weights and save.
+
+        Calls PEFT's ``merge_and_unload()`` on a copy of the model, then saves
+        the merged weights with ``save_pretrained``.  The original model
+        (with adapters) is left unchanged.
+
+        Args:
+            model:              PEFT-wrapped dLLM model (output of ``get_peft_model``).
+            save_directory:     Local directory path to save the merged model.
+            tokenizer:          Optional tokenizer to save alongside the model.
+            safe_serialization: Use safetensors format (recommended).
+            **kwargs:           Forwarded to ``save_pretrained``.
+        """
+        import copy
+
+        _logger.info("FastDiffusionModel: merging LoRA adapters into base weights …")
+        merged = copy.deepcopy(model)
+        # merge_and_unload returns the unwrapped base model with adapters merged.
+        merged = merged.merge_and_unload()
+        merged.save_pretrained(
+            save_directory,
+            safe_serialization=safe_serialization,
+            **kwargs,
+        )
+        _logger.info("FastDiffusionModel: merged model saved to %r", save_directory)
+        if tokenizer is not None:
+            tokenizer.save_pretrained(save_directory)
+            _logger.info("FastDiffusionModel: tokenizer saved to %r", save_directory)
+
+    @staticmethod
+    def push_to_hub_merged(
+        model: Any,
+        repo_id: str,
+        tokenizer: Any = None,
+        safe_serialization: bool = True,
+        token: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Merge LoRA adapters and push merged weights to the HuggingFace Hub.
+
+        Merges adapters via PEFT's ``merge_and_unload()`` then calls
+        ``push_to_hub`` on the merged model.  The original model is unchanged.
+
+        Args:
+            model:              PEFT-wrapped dLLM model.
+            repo_id:            HuggingFace Hub repository id (e.g. ``"user/my-model"``).
+            tokenizer:          Optional tokenizer to push alongside the model.
+            safe_serialization: Use safetensors format.
+            token:              HuggingFace auth token.
+            **kwargs:           Forwarded to ``push_to_hub``.
+        """
+        import copy
+
+        _logger.info("FastDiffusionModel: merging LoRA adapters for Hub push …")
+        merged = copy.deepcopy(model)
+        merged = merged.merge_and_unload()
+
+        push_kwargs: dict[str, Any] = dict(safe_serialization=safe_serialization, **kwargs)
+        if token is not None:
+            push_kwargs["token"] = token
+
+        merged.push_to_hub(repo_id, **push_kwargs)
+        _logger.info("FastDiffusionModel: merged model pushed to %r", repo_id)
+        if tokenizer is not None:
+            tok_kwargs: dict[str, Any] = {}
+            if token is not None:
+                tok_kwargs["token"] = token
+            tokenizer.push_to_hub(repo_id, **tok_kwargs)
+
+    @staticmethod
+    @contextlib.contextmanager
+    def inference_context(model: Any):
+        """Context manager that temporarily switches to inference mode.
+
+        Restores training mode on exit.
+
+        Usage::
+
+            with FastDiffusionModel.inference_context(model):
+                logits = model(**inputs).logits
+
+        Args:
+            model: A dLLM model (plain or PEFT-wrapped).
+        """
+        was_training = model.training
+        FastDiffusionModel.for_inference(model)
+        try:
+            with torch.no_grad():
+                yield model
+        finally:
+            if was_training:
+                FastDiffusionModel.for_training(model)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `for_inference(model)` — eval mode + gradient checkpointing disabled
- `for_training(model)` — train mode + optional gradient checkpointing (unsloth-style or standard)
- `save_pretrained_merged(model, path, tokenizer)` — LoRA merge via PEFT `merge_and_unload()` then `save_pretrained`
- `push_to_hub_merged(model, repo_id, tokenizer)` — LoRA merge then `push_to_hub`
- `inference_context(model)` — context manager: eval+no_grad inside, restores train mode on exit
- `TODO(Phase Z)` comment on unsloth GC import in `for_training`

Closes #45

## Test plan

- [x] `TestInferenceTrainingMethods` (7 tests) — eval/train toggle, context manager, no_grad
- [x] `TestSavePretrainedMerged` (3 tests) — files written, original model intact, tokenizer saved
- [x] 179 total tests pass, 1 skipped (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)