### PR TITLE
✨ feat(eval): add Phase G evaluation harness (#55)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,3 +220,4 @@ server.pid
 *.log
 package-lock.json
 dev/*.md
+.serena/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,11 +94,15 @@ python -m pytest tests/ -v  # (no -race for Python, but run on GPU if kernel cha
    - For transformers API compatibility (post_init, tie_weights, BnB quantizer, init_weights):
      `dev/repos/transformers/src/transformers/modeling_utils.py`,
      `dev/repos/transformers/src/transformers/integrations/bitsandbytes.py`
+   - For KV cache / block decoding (Phase J):
+     `dev/repos/fast-dllm/dream/model/generation_utils_block.py`,
+     `dev/repos/fast-dllm/llada/model/modeling_llada.py`
    - If `dev/repos/` is not cloned, run:
      ```bash
      git clone https://github.com/dllm-reasoning/d1.git dev/repos/d1
      git clone https://github.com/zhziszz/dllm.git dev/repos/dllm
      git clone --depth=1 https://github.com/huggingface/transformers.git dev/repos/transformers
+     git clone --depth=1 https://github.com/NVlabs/Fast-dLLM.git dev/repos/fast-dllm
      ```
 
 2. **Behavioral differences from reference must be intentional** — Do not classify a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,7 @@ mkdir -p dev/repos
 git clone https://github.com/dllm-reasoning/d1.git dev/repos/d1
 git clone https://github.com/zhziszz/dllm.git dev/repos/dllm
 git clone --depth=1 https://github.com/huggingface/transformers.git dev/repos/transformers
+git clone --depth=1 https://github.com/NVlabs/Fast-dLLM.git dev/repos/fast-dllm
 ```
 
 | ディレクトリ | リポジトリ | 参照すべきファイル |
@@ -203,6 +204,7 @@ git clone --depth=1 https://github.com/huggingface/transformers.git dev/repos/tr
 | `dev/repos/d1/` | [dllm-reasoning/d1](https://github.com/dllm-reasoning/d1) | `SFT/sft_trainer.py`, `diffu-grpo/diffu_grpo_trainer.py` |
 | `dev/repos/dllm/` | [zhziszz/dllm](https://github.com/zhziszz/dllm) | `dllm/core/trainers/mdlm.py`, `dllm/core/schedulers/alpha.py` |
 | `dev/repos/transformers/` | [huggingface/transformers](https://github.com/huggingface/transformers) | `src/transformers/modeling_utils.py` (post_init, tie_weights, get_keys_to_not_convert), `src/transformers/integrations/bitsandbytes.py` |
+| `dev/repos/fast-dllm/` | [NVlabs/Fast-dLLM](https://github.com/NVlabs/Fast-dLLM) (Apache 2.0) | `dream/model/generation_utils_block.py` (ブロックデコード KV cache), `llada/model/modeling_llada.py` (`use_cache`/`replace_position` 実装), `v2/generation_functions.py` |
 
 詳細は `dev/06_references.md` を参照。
 
@@ -390,7 +392,7 @@ upstream unsloth のスタイル (`fix: description (#N)`) とも互換。emoji 
 Please review PR #N on branch <branch> in /grouper/nishide.21066-1000003/projects/unturtle.
 Run: git diff main...HEAD
 Focus on:
-1. Reference implementation alignment (dev/repos/d1/, dev/repos/dllm/, dev/repos/transformers/)
+1. Reference implementation alignment (dev/repos/d1/, dev/repos/dllm/, dev/repos/transformers/, dev/repos/fast-dllm/)
 2. transformers 5.x API compatibility (post_init, tie_weights(**kwargs), BnB quantizer)
 3. CUDA guards on all Triton/Flash paths (device.type == "cuda", not just HAS_FLASH_ATTENTION)
 4. Bidirectional attention: is_causal=False preserved everywhere
@@ -409,6 +411,7 @@ CRITICAL/HIGH 指摘は必ず修正してから merge すること。
   - `dev/repos/d1/SFT/sft_trainer.py` — d1 SFT の参照実装
   - `dev/repos/dllm/dllm/core/trainers/mdlm.py` — MDLM/LLaDA の参照実装
   - `dev/repos/transformers/src/transformers/modeling_utils.py` — `post_init`, `tie_weights`, BnB quantizer との互換性
+  - `dev/repos/fast-dllm/dream/model/generation_utils_block.py` — ブロックデコード KV cache の参照実装 (Phase J)
 - 参照実装と異なる挙動を「バグ」と判定する前に、意図的な設計変更か否かを確認する
 
 **ドキュメント更新**:

--- a/tests/diffusion/test_integration.py
+++ b/tests/diffusion/test_integration.py
@@ -36,7 +36,9 @@ from unturtle.diffusion import (
     DiffusionTrainingArguments,
     LinearAlphaScheduler,
     MaskedDiffusionDataCollator,
+    PackedMaskedDiffusionDataCollator,
 )
+from unturtle.eval import MaskedDiffusionEvaluator
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -134,8 +136,6 @@ class TestDiffusionTrainerComputeLoss:
         input_ids = batch["input_ids"]
         labels = batch["labels"]
         diffusion_mask = batch["diffusion_mask"]
-        timesteps = batch["timesteps"]
-
         outputs = model(input_ids=input_ids, labels=None)
         logits = outputs.logits  # [B, L, V]
 
@@ -256,6 +256,8 @@ class TestLossWeightTypes:
             w = scheduler.weight(timesteps)
             loss_weights = w
 
+        if loss_weights is not None:
+            loss_weights = loss_weights.to(logits.device)
         loss = fast_masked_diffusion_loss(logits, labels, diffusion_mask, loss_weights)
         assert not torch.isnan(loss), f"NaN loss with weight_type={weight_type}"
         assert loss.item() >= 0, f"Negative loss with weight_type={weight_type}"
@@ -282,6 +284,20 @@ class TestCollatorIntegration:
         batch = collator(samples)
         for key in ("input_ids", "labels", "diffusion_mask", "timesteps"):
             assert key in batch, f"Missing key: {key}"
+
+    def test_collator_pads_variable_length_inputs(self, tokenizer):
+        scheduler = LinearAlphaScheduler()
+        collator = MaskedDiffusionDataCollator(
+            tokenizer=tokenizer,
+            scheduler=scheduler,
+            mask_token_id=tokenizer.mask_token_id,
+        )
+        batch = collator([
+            {"input_ids": [5, 6, 7], "attention_mask": [1, 1, 1]},
+            {"input_ids": [8, 9, 10, 11, 12], "attention_mask": [1, 1, 1, 1, 1]},
+        ])
+        assert batch["input_ids"].shape == (2, 5)
+        assert batch["attention_mask"].shape == (2, 5)
 
     def test_collator_mask_token_applied(self, tokenizer):
         scheduler = LinearAlphaScheduler()
@@ -316,6 +332,25 @@ class TestCollatorIntegration:
         batch = collator(samples)
         prompt_mask = batch["diffusion_mask"][:, :prompt_len]
         assert not prompt_mask.any(), "Prompt positions must never be masked"
+
+    def test_collator_pads_variable_length_labels(self, tokenizer):
+        scheduler = LinearAlphaScheduler()
+        collator = MaskedDiffusionDataCollator(
+            tokenizer=tokenizer,
+            scheduler=scheduler,
+            mask_token_id=tokenizer.mask_token_id,
+            completion_only=True,
+        )
+        batch = collator([
+            {"input_ids": [5, 6, 7], "labels": [-100, 6, 7], "attention_mask": [1, 1, 1]},
+            {"input_ids": [8, 9, 10, 11, 12], "labels": [-100, -100, 10, 11, 12], "attention_mask": [1, 1, 1, 1, 1]},
+        ])
+        assert batch["input_ids"].shape == (2, 5)
+        assert batch["labels"].shape == (2, 5)
+        assert batch["labels"].tolist() == [
+            [-100, 6, 7, -100, -100],
+            [-100, -100, 10, 11, 12],
+        ]
 
 
 # ---------------------------------------------------------------------------
@@ -370,3 +405,114 @@ class TestBidirectionalAttention:
         # In a causal model, changing position L-1 should NOT affect position 0
         diff = (out_original[0, 0] - out_modified[0, 0]).abs().max().item()
         assert diff == 0.0, "GPT-2 should NOT show future-token influence (causal)"
+
+
+# ---------------------------------------------------------------------------
+# A-5: Evaluation helper smoke test
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluationHelpers:
+    @pytest.fixture
+    def tokenizer(self):
+        return _make_tokenizer()
+
+    def test_trainer_evaluate_diffusion_helper_runs(self, tokenizer, tmp_path):
+        model = _make_bert("cpu")
+        dataset = Dataset.from_list([
+            {
+                "input_ids": torch.randint(5, VOCAB_SIZE, (SEQ_LEN,)).tolist(),
+                "labels": [-100] * 4 + torch.randint(5, VOCAB_SIZE, (SEQ_LEN - 4,)).tolist(),
+                "attention_mask": [1] * SEQ_LEN,
+            }
+            for _ in range(4)
+        ])
+        args = DiffusionTrainingArguments(
+            output_dir=str(tmp_path / "eval"),
+            per_device_train_batch_size=2,
+            remove_unused_columns=False,
+            report_to="none",
+            use_cpu=True,
+            bf16=False,
+            fp16=False,
+            max_steps=1,
+        )
+        trainer = DiffusionTrainer(
+            model=model,
+            args=args,
+            train_dataset=dataset,
+            eval_dataset=dataset,
+            processing_class=tokenizer,
+        )
+        metrics = trainer.evaluate_diffusion(dataset, batch_size=2)
+        assert metrics["eval_num_batches"] == 2.0
+        assert metrics["eval_loss"] >= 0.0
+
+    def test_trainer_uses_model_config_mask_token_id_fallback(self, tokenizer, tmp_path):
+        tokenizer.mask_token = None
+        tokenizer.mask_token_id = None
+        model = _make_bert("cpu")
+        model.config.mask_token_id = 2
+        dataset = Dataset.from_list([
+            {
+                "input_ids": torch.randint(5, VOCAB_SIZE, (SEQ_LEN,)).tolist(),
+                "labels": [-100] * 4 + torch.randint(5, VOCAB_SIZE, (SEQ_LEN - 4,)).tolist(),
+                "attention_mask": [1] * SEQ_LEN,
+            }
+            for _ in range(2)
+        ])
+        args = DiffusionTrainingArguments(
+            output_dir=str(tmp_path / "eval-fallback"),
+            per_device_train_batch_size=2,
+            remove_unused_columns=False,
+            report_to="none",
+            use_cpu=True,
+            bf16=False,
+            fp16=False,
+            max_steps=1,
+        )
+        trainer = DiffusionTrainer(
+            model=model,
+            args=args,
+            train_dataset=dataset,
+            eval_dataset=dataset,
+            processing_class=tokenizer,
+        )
+        assert trainer.data_collator.mask_token_id == 2
+
+    def test_trainer_rejects_packed_non_uniform_weighting(self, tokenizer, tmp_path):
+        model = _make_bert("cpu")
+        dataset = Dataset.from_list([
+            {
+                "input_ids": torch.randint(5, VOCAB_SIZE, (SEQ_LEN,)).tolist(),
+                "labels": [-100] * 4 + torch.randint(5, VOCAB_SIZE, (SEQ_LEN - 4,)).tolist(),
+                "attention_mask": [1] * SEQ_LEN,
+            }
+            for _ in range(2)
+        ])
+        args = DiffusionTrainingArguments(
+            output_dir=str(tmp_path / "packed-weighting"),
+            per_device_train_batch_size=2,
+            remove_unused_columns=False,
+            report_to="none",
+            use_cpu=True,
+            bf16=False,
+            fp16=False,
+            max_steps=1,
+            loss_weight_type="timestep",
+        )
+        packed_collator = PackedMaskedDiffusionDataCollator(
+            tokenizer=tokenizer,
+            max_seq_length=SEQ_LEN,
+            scheduler=LinearAlphaScheduler(),
+            mask_token_id=tokenizer.mask_token_id,
+        )
+        with pytest.raises(ValueError, match="PackedMaskedDiffusionDataCollator"):
+            DiffusionTrainer(
+                model=model,
+                args=args,
+                train_dataset=dataset,
+                eval_dataset=dataset,
+                processing_class=tokenizer,
+                data_collator=packed_collator,
+            )

--- a/tests/diffusion/test_masked_diffusion_loss.py
+++ b/tests/diffusion/test_masked_diffusion_loss.py
@@ -330,15 +330,16 @@ class TestMaskedDiffusionDataCollator:
             "Some masked positions do not contain mask_token_id"
         )
 
-    def test_labels_minus100_at_unmasked(self):
-        """Unmasked positions must have label == -100."""
+    def test_labels_preserve_maskable_targets(self):
+        """Maskable positions must keep their clean target ids."""
         collator = self.MaskedDiffusionDataCollator(
             tokenizer=self._make_tokenizer(),
             scheduler=self.LinearAlphaScheduler(),
         )
-        batch = collator(self._make_features())
-        unmasked_labels = batch["labels"][~batch["diffusion_mask"]]
-        assert (unmasked_labels == -100).all()
+        features = self._make_features()
+        batch = collator(features)
+        expected = torch.stack([f["labels"] for f in features])
+        assert torch.equal(batch["labels"], expected)
 
     def test_no_mask_token_raises(self):
         class NoMaskTok:

--- a/tests/diffusion/test_packed_collator.py
+++ b/tests/diffusion/test_packed_collator.py
@@ -94,14 +94,14 @@ class TestPackedShape:
             assert real > 0, "No real tokens in row"
             assert real <= 32
 
-    def test_labels_minus100_at_unmasked(self, collator):
-        """positions not in diffusion_mask must have label == -100."""
+    def test_labels_preserve_maskable_targets(self, collator):
+        """Real non-padding positions must keep their clean target ids."""
         samples = _make_samples(4, 8)
         batch = collator(samples)
-        dm = batch["diffusion_mask"]  # [B, L] bool
-        lbl = batch["labels"]         # [B, L]
-        # Unmasked non-padding positions should be -100
-        assert (lbl[~dm] == -100).all(), "Un-masked positions must have label -100"
+        attn = batch["attention_mask"].bool()
+        lbl = batch["labels"]
+        assert (lbl[attn] != -100).all(), "Real positions must keep clean labels"
+        assert (lbl[~attn] == -100).all(), "Padding positions must remain -100"
 
     def test_position_ids_reset_per_sample(self, collator):
         """position_ids must restart from 0 for each packed sample."""
@@ -285,9 +285,23 @@ class TestAttentionBoundaries:
         samples = _make_samples(2, 6)
         batch = coll(samples)
         assert "block_attention_mask" in batch
-        B, one, L1, L2 = batch["block_attention_mask"].shape
+        _, one, L1, L2 = batch["block_attention_mask"].shape
         assert one == 1
         assert L1 == L2 == 16
+
+    def test_block_diagonal_mask_present_even_when_flash_available(self, tokenizer, monkeypatch):
+        """CPU/SDPA fallback still needs block_attention_mask even if flash_attn is importable."""
+        from unturtle.diffusion import packed_collator as pc
+        monkeypatch.setattr(pc, "_FLASH_ATTN_AVAILABLE", True)
+
+        from unturtle.diffusion.packed_collator import PackedMaskedDiffusionDataCollator
+        coll = PackedMaskedDiffusionDataCollator(
+            tokenizer=tokenizer,
+            max_seq_length=16,
+            completion_only=False,
+        )
+        batch = coll(_make_samples(2, 6))
+        assert "block_attention_mask" in batch
 
     def test_samples_do_not_attend_across_boundaries(self, tokenizer, monkeypatch):
         """In the block-diagonal mask, positions from different samples must not attend."""

--- a/tests/eval/test_evaluators.py
+++ b/tests/eval/test_evaluators.py
@@ -1,0 +1,215 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pytest
+import torch
+from datasets import Dataset
+
+from unturtle.diffusion import PackedMaskedDiffusionDataCollator
+from unturtle.eval import GenerationEvaluator, MaskedDiffusionEvaluator
+
+from tests.diffusion.test_integration import _make_tokenizer, _make_bert, VOCAB_SIZE, SEQ_LEN
+
+
+def _make_diffusion_dataset(num_rows: int = 6, prompt_len: int = 4) -> Dataset:
+    rows = []
+    for _ in range(num_rows):
+        ids = torch.randint(5, VOCAB_SIZE, (SEQ_LEN,)).tolist()
+        labels = [-100] * prompt_len + ids[prompt_len:]
+        rows.append(
+            {
+                "input_ids": ids,
+                "labels": labels,
+                "attention_mask": [1] * SEQ_LEN,
+            }
+        )
+    return Dataset.from_list(rows)
+
+
+class TinyDiffusionModel(torch.nn.Module):
+    def __init__(self, mask_token_id: int | None = None):
+        super().__init__()
+        self.calls = 0
+        self.last_attention_mask = None
+        self.dummy = torch.nn.Parameter(torch.zeros(1))
+        self.config = type("Config", (), {"mask_token_id": mask_token_id})()
+
+    def diffusion_generate(self, input_ids, max_length=None, attention_mask=None, **_kwargs):
+        self.calls += 1
+        self.last_attention_mask = attention_mask.clone() if attention_mask is not None else None
+        out = input_ids.clone()
+        target_length = max_length or out.shape[1]
+        if target_length > out.shape[1]:
+            pad = torch.full(
+                (out.shape[0], target_length - out.shape[1]),
+                7,
+                dtype=out.dtype,
+                device=out.device,
+            )
+            return torch.cat([out, pad], dim=1)
+        if out.shape[1] > 0:
+            out[:, -1] = 7
+        return out
+
+
+class TestMaskedDiffusionEvaluator:
+    @pytest.fixture
+    def tokenizer(self):
+        return _make_tokenizer()
+
+    def test_evaluate_returns_expected_keys(self, tokenizer):
+        model = _make_bert("cpu")
+        evaluator = MaskedDiffusionEvaluator(model=model, tokenizer=tokenizer)
+        metrics = evaluator.evaluate(_make_diffusion_dataset(), batch_size=2)
+        assert set(metrics) == {
+            "eval_loss",
+            "eval_masked_token_nll",
+            "eval_perplexity",
+            "eval_mask_rate",
+            "eval_num_batches",
+        }
+        assert metrics["eval_num_batches"] == 3.0
+        assert metrics["eval_loss"] >= 0.0
+
+    def test_evaluate_respects_max_batches(self, tokenizer):
+        model = _make_bert("cpu")
+        evaluator = MaskedDiffusionEvaluator(model=model, tokenizer=tokenizer)
+        metrics = evaluator.evaluate(_make_diffusion_dataset(num_rows=8), batch_size=2, max_batches=2)
+        assert metrics["eval_num_batches"] == 2.0
+
+    def test_evaluate_uses_completion_only_masking(self, tokenizer):
+        model = _make_bert("cpu")
+        evaluator = MaskedDiffusionEvaluator(
+            model=model,
+            tokenizer=tokenizer,
+            completion_only=True,
+        )
+        metrics = evaluator.evaluate(_make_diffusion_dataset(num_rows=4, prompt_len=6), batch_size=2)
+        assert 0.0 <= metrics["eval_mask_rate"] <= 1.0
+
+    def test_evaluator_uses_model_config_mask_token_id_fallback(self, tokenizer):
+        tokenizer.mask_token = None
+        tokenizer.mask_token_id = None
+        model = _make_bert("cpu")
+        model.config.mask_token_id = 2
+        evaluator = MaskedDiffusionEvaluator(model=model, tokenizer=tokenizer)
+        assert evaluator.data_collator.mask_token_id == 2
+
+    def test_mask_rate_uses_maskable_tokens(self, tokenizer):
+        model = _make_bert("cpu")
+        evaluator = MaskedDiffusionEvaluator(model=model, tokenizer=tokenizer)
+        metrics = evaluator.evaluate(_make_diffusion_dataset(num_rows=4, prompt_len=8), batch_size=2)
+        assert 0.0 <= metrics["eval_mask_rate"] < 1.0
+
+    def test_weighted_eval_reports_unweighted_nll_and_perplexity(self, tokenizer):
+        model = _make_bert("cpu")
+        evaluator = MaskedDiffusionEvaluator(
+            model=model,
+            tokenizer=tokenizer,
+            loss_weight_type="timestep",
+        )
+        metrics = evaluator.evaluate(_make_diffusion_dataset(num_rows=4), batch_size=2)
+        assert metrics["eval_loss"] != metrics["eval_masked_token_nll"]
+        assert metrics["eval_perplexity"] >= 1.0
+
+    def test_evaluator_rejects_packed_non_uniform_weighting(self, tokenizer):
+        model = _make_bert("cpu")
+        collator = PackedMaskedDiffusionDataCollator(
+            tokenizer=tokenizer,
+            max_seq_length=SEQ_LEN,
+            scheduler=None,
+            mask_token_id=tokenizer.mask_token_id,
+        )
+        with pytest.raises(ValueError, match="PackedMaskedDiffusionDataCollator"):
+            MaskedDiffusionEvaluator(
+                model=model,
+                tokenizer=tokenizer,
+                data_collator=collator,
+                loss_weight_type="timestep",
+            )
+
+
+class TestGenerationEvaluator:
+    def test_generation_metrics_return_expected_keys(self):
+        model = TinyDiffusionModel()
+        evaluator = GenerationEvaluator(model=model, tokenizer=None)
+        dataset = [{"input_ids": [1, 2, 3, 0], "references": [7]}]
+        metrics = evaluator.evaluate(dataset)
+        assert set(metrics) == {"gen_exact_match", "gen_token_accuracy", "gen_num_examples"}
+        assert metrics["gen_num_examples"] == 1.0
+
+    def test_generation_uses_diffusion_generate(self):
+        model = TinyDiffusionModel()
+        evaluator = GenerationEvaluator(model=model, tokenizer=None)
+        dataset = [{"input_ids": [1, 2, 3, 0], "references": [7]}]
+        evaluator.evaluate(dataset)
+        assert model.calls == 1
+
+    def test_generation_exact_match_and_token_accuracy(self):
+        model = TinyDiffusionModel()
+        evaluator = GenerationEvaluator(model=model, tokenizer=None)
+        dataset = [
+            {"input_ids": [1, 2, 3, 0], "references": [7]},
+            {"input_ids": [4, 5, 6, 0], "references": [9]},
+        ]
+        metrics = evaluator.evaluate(dataset)
+        assert metrics["gen_exact_match"] == 0.5
+        assert metrics["gen_token_accuracy"] == 0.5
+
+    def test_generation_uses_prompt_prefix_from_labels(self):
+        model = TinyDiffusionModel()
+        evaluator = GenerationEvaluator(model=model, tokenizer=None)
+        dataset = [
+            {
+                "input_ids": [1, 2, 3, 4],
+                "labels": [-100, -100, 7, 7],
+            }
+        ]
+        metrics = evaluator.evaluate(dataset)
+        assert metrics["gen_exact_match"] == 1.0
+        assert metrics["gen_token_accuracy"] == 1.0
+
+    def test_generation_trims_padding_and_passes_attention_mask(self):
+        model = TinyDiffusionModel()
+        evaluator = GenerationEvaluator(model=model, tokenizer=None)
+        dataset = [
+            {
+                "input_ids": [1, 2, 7, 7, 0, 0],
+                "labels": [-100, -100, 7, 7, -100, -100],
+                "attention_mask": [1, 1, 1, 1, 0, 0],
+            }
+        ]
+        metrics = evaluator.evaluate(dataset)
+        assert metrics["gen_exact_match"] == 1.0
+        assert metrics["gen_token_accuracy"] == 1.0
+        assert model.last_attention_mask is not None
+        assert model.last_attention_mask.tolist() == [[1, 1]]
+
+    def test_generation_handles_left_padding(self):
+        model = TinyDiffusionModel()
+        evaluator = GenerationEvaluator(model=model, tokenizer=None)
+        dataset = [
+            {
+                "input_ids": [0, 0, 1, 2, 7, 7],
+                "labels": [-100, -100, -100, -100, 7, 7],
+                "attention_mask": [0, 0, 1, 1, 1, 1],
+            }
+        ]
+        metrics = evaluator.evaluate(dataset)
+        assert metrics["gen_exact_match"] == 1.0
+        assert metrics["gen_token_accuracy"] == 1.0
+        assert model.last_attention_mask is not None
+        assert model.last_attention_mask.tolist() == [[1, 1]]

--- a/unturtle/__init__.py
+++ b/unturtle/__init__.py
@@ -63,6 +63,11 @@ from unturtle.kernels.fused_masked_diffusion_loss import (  # noqa: F401
     fused_masked_diffusion_loss,
 )
 from unturtle.fast_diffusion_model import FastDiffusionModel  # noqa: F401
+from unturtle.eval import (  # noqa: F401
+    BaseEvaluator,
+    GenerationEvaluator,
+    MaskedDiffusionEvaluator,
+)
 
 # ---------------------------------------------------------------------------
 # dLLM model classes

--- a/unturtle/diffusion/collator.py
+++ b/unturtle/diffusion/collator.py
@@ -21,7 +21,7 @@ diffusion timestep ``t``) and replaces them with the ``[MASK]`` token id.  The
 resulting batch contains:
 
   ``input_ids``      – noised token ids (masked positions → mask_token_id)
-  ``labels``         – clean token ids (``x_0``); unmasked positions → -100
+  ``labels``         – clean token ids (``x_0``); prompt/padding positions → -100
   ``diffusion_mask`` – bool tensor, True at masked positions
   ``timesteps``      – sampled ``t`` values, shape ``(B,)``
 
@@ -37,7 +37,7 @@ from typing import Any
 
 import torch
 from transformers import PreTrainedTokenizerBase
-from transformers.data.data_collator import default_data_collator
+from transformers.data.data_collator import default_data_collator, pad_without_fast_tokenizer_warning
 
 from .schedulers import BaseAlphaScheduler, LinearAlphaScheduler
 
@@ -90,8 +90,40 @@ class MaskedDiffusionDataCollator:
           ``input_ids``, ``attention_mask`` (if present), ``labels``,
           ``diffusion_mask``, ``timesteps``.
         """
-        # --- standard HF collation (padding, stacking) ---
-        batch = default_data_collator(features)
+        # --- standard HF collation with tokenizer-aware padding when available ---
+        if hasattr(self.tokenizer, "pad"):
+            has_labels = any("labels" in feature for feature in features)
+            features_to_pad = [
+                {k: v for k, v in feature.items() if k != "labels"}
+                for feature in features
+            ]
+            batch = pad_without_fast_tokenizer_warning(
+                self.tokenizer,
+                features_to_pad,
+                padding=True,
+                return_tensors="pt",
+            )
+
+            if has_labels:
+                seq_len = batch["input_ids"].shape[1]
+                padding_side = getattr(self.tokenizer, "padding_side", "right")
+                padded_labels = []
+                for feature in features:
+                    if "labels" in feature:
+                        labels = list(feature["labels"])
+                    else:
+                        labels = [-100] * len(feature["input_ids"])
+
+                    pad_len = seq_len - len(labels)
+                    if padding_side == "left":
+                        labels = ([-100] * pad_len) + labels
+                    else:
+                        labels = labels + ([-100] * pad_len)
+                    padded_labels.append(labels)
+
+                batch["labels"] = torch.tensor(padded_labels, dtype=torch.long)
+        else:
+            batch = default_data_collator(features)
 
         input_ids: torch.Tensor = batch["input_ids"]  # [B, L]
         B, L = input_ids.shape
@@ -114,7 +146,7 @@ class MaskedDiffusionDataCollator:
         ) * torch.rand(B, device=device)  # [B], in (eps, 1]
 
         # --- compute per-token masking probability p_mask = 1 - alpha(t) ---
-        alpha_t: torch.Tensor = self.scheduler.alpha(t)  # [B]
+        alpha_t = torch.as_tensor(self.scheduler.alpha(t), device=device, dtype=t.dtype)  # [B]
         p_mask: torch.Tensor = (1.0 - alpha_t).unsqueeze(1).expand(B, L)  # [B, L]
 
         # --- stochastic masking (Bernoulli) ---
@@ -125,9 +157,13 @@ class MaskedDiffusionDataCollator:
         noised_input_ids = input_ids.clone()
         noised_input_ids[diffusion_mask] = self.mask_token_id
 
-        # --- build labels: clean tokens at masked positions, -100 elsewhere ---
-        labels = input_ids.clone()
-        labels[~diffusion_mask] = -100
+        # --- build labels: keep clean targets for all maskable positions ---
+        if self.completion_only and "labels" in batch:
+            labels = batch["labels"].clone()
+        else:
+            labels = input_ids.clone()
+            if "attention_mask" in batch:
+                labels[~batch["attention_mask"].bool()] = -100
 
         batch["input_ids"] = noised_input_ids
         batch["labels"] = labels

--- a/unturtle/diffusion/packed_collator.py
+++ b/unturtle/diffusion/packed_collator.py
@@ -147,14 +147,15 @@ class PackedMaskedDiffusionDataCollator:
         if self.completion_only and "labels" in feature:
             raw_labels = list(feature["labels"])[:length]
             maskable = [lbl != -100 for lbl in raw_labels]
+            labels = list(raw_labels)
         else:
             # attention_mask or all-True
             if "attention_mask" in feature:
                 maskable = [bool(m) for m in list(feature["attention_mask"])[:length]]
             else:
                 maskable = [True] * length
+            labels = list(ids)
 
-        labels = list(ids)  # clean token ids (will be modified in-place below)
         return ids, labels, maskable
 
     def _pack_samples(
@@ -193,7 +194,7 @@ class PackedMaskedDiffusionDataCollator:
 
         Returns a dict with keys:
           ``input_ids``       – [B, max_seq_length] packed + padded noised ids
-          ``labels``          – [B, max_seq_length] clean ids at masked pos, -100 else
+          ``labels``          – [B, max_seq_length] clean ids at maskable pos, -100 at prompt/pad
           ``attention_mask``  – [B, max_seq_length] 1 at real tokens, 0 at pad
           ``diffusion_mask``  – [B, max_seq_length] bool, True at masked positions
           ``timesteps``           – [B] mean ``t`` per row (DiffusionTrainer compatible)
@@ -247,9 +248,7 @@ class PackedMaskedDiffusionDataCollator:
                 ts.append(t_val)
 
                 # Compute masking probability and Bernoulli mask
-                alpha_t = self.scheduler.alpha(
-                    torch.tensor([t_val])
-                ).item()
+                alpha_t = float(torch.as_tensor(self.scheduler.alpha(torch.tensor([t_val]))).item())
                 p_mask = 1.0 - alpha_t
 
                 rand = torch.rand(slen)
@@ -260,9 +259,8 @@ class PackedMaskedDiffusionDataCollator:
                 noised = torch.tensor(ids, dtype=torch.long)
                 noised[diff_mask] = self.mask_token_id
 
-                # Build labels for this sample: clean at masked, -100 elsewhere
+                # Keep clean labels for all maskable positions; prompt/pad stay -100.
                 lbl = torch.tensor(clean_labels, dtype=torch.long)
-                lbl[~diff_mask] = -100
 
                 # Position ids restart at 0 for each sample in the packed seq
                 pos = torch.arange(slen, dtype=torch.long)
@@ -311,28 +309,21 @@ class PackedMaskedDiffusionDataCollator:
             "sample_timesteps": all_timesteps,     # list[Tensor] — per-sample granularity
         }
 
-        # 4. Build attention bias for the model forward pass
-        if _FLASH_ATTN_AVAILABLE:
-            # Flash Attention varlen path: just pass cu_seqlens.
-            # The model's A2DAttention_fast_forward reads cu_seqlens from
-            # get_packed_info_from_kwargs when attention_mask shape triggers it.
-            # We keep attention_mask as the standard 2D mask; cu_seqlens is the
-            # authoritative source for Flash Attention block boundaries.
-            pass  # cu_seqlens already in batch
-        else:
-            # SDPA fallback: build a dense block-diagonal mask for each batch element.
-            # Shape: [B, 1, L, L] — True where attention is allowed.
-            device = out_input_ids.device
-            sdpa_masks = []
-            for b, (group, _) in enumerate(packed_groups):
-                seq_lens_b = [len(s[0]) for s in group]
-                total = sum(seq_lens_b)
-                m = _build_block_diagonal_mask(seq_lens_b, total, device)
-                # Pad to [1, 1, L, L]
-                padded = torch.zeros(1, 1, L, L, dtype=torch.bool, device=device)
-                padded[:, :, :total, :total] = m
-                sdpa_masks.append(padded)
-            batch["block_attention_mask"] = torch.cat(sdpa_masks, dim=0)  # [B, 1, L, L]
+        # 4. Always build the dense block-diagonal mask for non-Flash fallbacks.
+        # Even when flash_attn is installed, CPU execution and other fallback paths
+        # still need an explicit bidirectional block mask to preserve sample boundaries.
+        device = out_input_ids.device
+        sdpa_masks = []
+        for group, _ in packed_groups:
+            seq_lens_b = [len(s[0]) for s in group]
+            total = sum(seq_lens_b)
+            m = _build_block_diagonal_mask(seq_lens_b, total, device)
+            padded = torch.zeros(1, 1, L, L, dtype=torch.bool, device=device)
+            padded[:, :, :total, :total] = m
+            sdpa_masks.append(padded)
+        batch["block_attention_mask"] = torch.cat(sdpa_masks, dim=0)  # [B, 1, L, L]
+
+        if not _FLASH_ATTN_AVAILABLE:
             logger.debug(
                 "PackedMaskedDiffusionDataCollator: Flash Attention not available, "
                 "using dense block-diagonal SDPA mask."

--- a/unturtle/diffusion/trainer.py
+++ b/unturtle/diffusion/trainer.py
@@ -40,9 +40,11 @@ from typing import Any
 import torch
 
 from unsloth.trainer import UnslothTrainer, UnslothTrainingArguments
+from unturtle.eval import GenerationEvaluator, MaskedDiffusionEvaluator
 from unturtle.kernels.masked_diffusion_loss import fast_masked_diffusion_loss
 
 from .collator import MaskedDiffusionDataCollator
+from .packed_collator import PackedMaskedDiffusionDataCollator
 from .schedulers import BaseAlphaScheduler, LinearAlphaScheduler, make_alpha_scheduler
 
 
@@ -138,18 +140,31 @@ class DiffusionTrainer(UnslothTrainer):
         self._loss_weight_type: str = getattr(args, "loss_weight_type", "uniform")
         completion_only: bool = getattr(args, "completion_only", True)
 
+        model = kwargs.get("model") or (pargs[0] if pargs else None)
+
         # Inject MaskedDiffusionDataCollator unless the caller supplied one
         if "data_collator" not in kwargs or kwargs["data_collator"] is None:
             tokenizer = kwargs.get("tokenizer") or kwargs.get("processing_class")
             if tokenizer is not None:
+                mask_token_id = getattr(tokenizer, "mask_token_id", None)
+                if mask_token_id is None:
+                    mask_token_id = getattr(getattr(model, "config", None), "mask_token_id", None)
                 kwargs["data_collator"] = MaskedDiffusionDataCollator(
                     tokenizer=tokenizer,
                     scheduler=self._alpha_scheduler,
+                    mask_token_id=mask_token_id,
                     time_epsilon=self._time_epsilon,
                     completion_only=completion_only,
                 )
 
         super().__init__(*pargs, **kwargs)
+
+        if isinstance(self.data_collator, PackedMaskedDiffusionDataCollator) and self._loss_weight_type != "uniform":
+            raise ValueError(
+                "PackedMaskedDiffusionDataCollator is not supported for diffusion training with "
+                "loss_weight_type='timestep' or 'scheduler'. Use uniform weighting or an "
+                "unpacked MaskedDiffusionDataCollator."
+            )
 
     # ------------------------------------------------------------------ #
     #  Loss computation                                                   #
@@ -161,13 +176,13 @@ class DiffusionTrainer(UnslothTrainer):
         inputs: dict[str, torch.Tensor | Any],
         return_outputs: bool = False,
         num_items_in_batch: torch.Tensor | int | None = None,
-        **kwargs: Any,
+        **_kwargs: Any,
     ) -> torch.Tensor | tuple[torch.Tensor, Any]:
         """Compute the masked diffusion CE loss using the Triton kernel.
 
         Expects ``inputs`` to contain:
           ``input_ids``      – noised token ids (from the data collator)
-          ``labels``         – clean token ids (``x_0``); ``-100`` at unmasked positions
+          ``labels``         – clean token ids (``x_0``); prompt/padding may be ``-100``
           ``diffusion_mask`` – bool tensor, True at masked positions
           ``timesteps``      – sampled ``t``, shape ``(B,)``
         """
@@ -187,13 +202,6 @@ class DiffusionTrainer(UnslothTrainer):
             loss_weights=loss_weights,
         )
 
-        # When num_items_in_batch is provided, normalize loss by it so that
-        # transformers' training_step does not also divide by gradient_accumulation_steps.
-        # (transformers 5.x training_step skips the /grad_accum normalization when
-        # compute_loss receives num_items_in_batch and num_items_in_batch is not None.)
-        if num_items_in_batch is not None:
-            loss = loss / num_items_in_batch
-
         return (loss, outputs) if return_outputs else loss
 
     # ------------------------------------------------------------------ #
@@ -204,13 +212,12 @@ class DiffusionTrainer(UnslothTrainer):
         self,
         timesteps: torch.Tensor,
         logits: torch.Tensor,
-        diffusion_mask: torch.Tensor,
+        _diffusion_mask: torch.Tensor,
     ) -> torch.Tensor | None:
         """Return per-token loss weights based on ``loss_weight_type``."""
         if self._loss_weight_type == "uniform":
             return None
 
-        B = logits.shape[0]
         device = logits.device
         t = timesteps.to(device)
 
@@ -226,4 +233,80 @@ class DiffusionTrainer(UnslothTrainer):
         raise ValueError(
             f"Unknown loss_weight_type '{self._loss_weight_type}'. "
             "Choose from: 'uniform', 'timestep', 'scheduler'."
+        )
+
+    def build_diffusion_evaluator(
+        self,
+        tokenizer: Any | None = None,
+        data_collator: Any | None = None,
+        metric_key_prefix: str = "eval",
+        **kwargs: Any,
+    ) -> MaskedDiffusionEvaluator:
+        tokenizer = tokenizer or getattr(self, "processing_class", None) or getattr(self, "tokenizer", None)
+        if tokenizer is None:
+            raise ValueError("Tokenizer or processing_class is required to build a diffusion evaluator.")
+
+        collator = data_collator or self.data_collator
+        if isinstance(collator, PackedMaskedDiffusionDataCollator) and self._loss_weight_type != "uniform":
+            raise ValueError(
+                "PackedMaskedDiffusionDataCollator is not supported for diffusion evaluation with "
+                "loss_weight_type='timestep' or 'scheduler'. Use uniform weighting or pass an "
+                "unpacked MaskedDiffusionDataCollator explicitly."
+            )
+
+        return MaskedDiffusionEvaluator(
+            model=self.model,
+            tokenizer=tokenizer,
+            data_collator=collator,
+            loss_weight_type=self._loss_weight_type,
+            alpha_scheduler=self._alpha_scheduler,
+            time_epsilon=self._time_epsilon,
+            completion_only=getattr(self.args, "completion_only", True),
+            metric_key_prefix=metric_key_prefix,
+            **kwargs,
+        )
+
+    def build_generation_evaluator(
+        self,
+        tokenizer: Any | None = None,
+        metric_key_prefix: str = "gen",
+        **kwargs: Any,
+    ) -> GenerationEvaluator:
+        tokenizer = tokenizer or getattr(self, "processing_class", None) or getattr(self, "tokenizer", None)
+        if tokenizer is None:
+            raise ValueError("Tokenizer or processing_class is required to build a generation evaluator.")
+
+        return GenerationEvaluator(
+            model=self.model,
+            tokenizer=tokenizer,
+            metric_key_prefix=metric_key_prefix,
+            **kwargs,
+        )
+
+    def evaluate_diffusion(
+        self,
+        dataset: Any,
+        batch_size: int = 1,
+        max_batches: int | None = None,
+        metric_key_prefix: str = "eval",
+        **kwargs: Any,
+    ) -> dict[str, float]:
+        evaluator = self.build_diffusion_evaluator(metric_key_prefix=metric_key_prefix, **kwargs)
+        return evaluator.evaluate(dataset=dataset, batch_size=batch_size, max_batches=max_batches)
+
+    def evaluate_generation(
+        self,
+        dataset: Any,
+        generation_config: Any | None = None,
+        batch_size: int = 1,
+        max_batches: int | None = None,
+        metric_key_prefix: str = "gen",
+        **kwargs: Any,
+    ) -> dict[str, float]:
+        evaluator = self.build_generation_evaluator(metric_key_prefix=metric_key_prefix, **kwargs)
+        return evaluator.evaluate(
+            dataset=dataset,
+            generation_config=generation_config,
+            batch_size=batch_size,
+            max_batches=max_batches,
         )

--- a/unturtle/diffusion/trainer.py
+++ b/unturtle/diffusion/trainer.py
@@ -159,6 +159,12 @@ class DiffusionTrainer(UnslothTrainer):
 
         super().__init__(*pargs, **kwargs)
 
+        # DiffusionTrainer normalizes loss by n_maskable tokens inside compute_loss.
+        # Setting this flag tells the Transformers Trainer NOT to apply its own
+        # gradient-accumulation normalization (loss / current_gradient_accumulation_steps),
+        # which would double-normalize.  See transformers Trainer.training_step L1925.
+        self.model_accepts_loss_kwargs = False
+
         if isinstance(self.data_collator, PackedMaskedDiffusionDataCollator) and self._loss_weight_type != "uniform":
             raise ValueError(
                 "PackedMaskedDiffusionDataCollator is not supported for diffusion training with "
@@ -298,8 +304,7 @@ class DiffusionTrainer(UnslothTrainer):
         self,
         dataset: Any,
         generation_config: Any | None = None,
-        batch_size: int = 1,
-        max_batches: int | None = None,
+        max_examples: int | None = None,
         metric_key_prefix: str = "gen",
         **kwargs: Any,
     ) -> dict[str, float]:
@@ -307,6 +312,5 @@ class DiffusionTrainer(UnslothTrainer):
         return evaluator.evaluate(
             dataset=dataset,
             generation_config=generation_config,
-            batch_size=batch_size,
-            max_batches=max_batches,
+            max_examples=max_examples,
         )

--- a/unturtle/diffusion/trainer.py
+++ b/unturtle/diffusion/trainer.py
@@ -159,10 +159,13 @@ class DiffusionTrainer(UnslothTrainer):
 
         super().__init__(*pargs, **kwargs)
 
-        # DiffusionTrainer normalizes loss by n_maskable tokens inside compute_loss.
-        # Setting this flag tells the Transformers Trainer NOT to apply its own
-        # gradient-accumulation normalization (loss / current_gradient_accumulation_steps),
-        # which would double-normalize.  See transformers Trainer.training_step L1925.
+        # DiffusionTrainer does NOT use num_items_in_batch in compute_loss.
+        # Setting model_accepts_loss_kwargs=False tells the Transformers Trainer to apply
+        # its standard gradient-accumulation scaling (loss / current_gradient_accumulation_steps).
+        # Note: fused_masked_diffusion_loss already normalizes by n_maskable per microbatch,
+        # so the effective accumulated loss is a mean-of-microbatch-means (approximate token
+        # weighting when token counts vary across microbatches).  This matches the d1/MDLM
+        # reference trainer behavior.  See transformers Trainer.training_step L1925.
         self.model_accepts_loss_kwargs = False
 
         if isinstance(self.data_collator, PackedMaskedDiffusionDataCollator) and self._loss_weight_type != "uniform":
@@ -279,8 +282,6 @@ class DiffusionTrainer(UnslothTrainer):
         **kwargs: Any,
     ) -> GenerationEvaluator:
         tokenizer = tokenizer or getattr(self, "processing_class", None) or getattr(self, "tokenizer", None)
-        if tokenizer is None:
-            raise ValueError("Tokenizer or processing_class is required to build a generation evaluator.")
 
         return GenerationEvaluator(
             model=self.model,

--- a/unturtle/eval/__init__.py
+++ b/unturtle/eval/__init__.py
@@ -1,0 +1,23 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .base import BaseEvaluator
+from .diffusion import MaskedDiffusionEvaluator
+from .generation import GenerationEvaluator
+
+__all__ = [
+    "BaseEvaluator",
+    "MaskedDiffusionEvaluator",
+    "GenerationEvaluator",
+]

--- a/unturtle/eval/base.py
+++ b/unturtle/eval/base.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from typing import Any, Iterator
 
@@ -21,8 +22,8 @@ import torch
 from torch.utils.data import DataLoader
 
 
-class BaseEvaluator:
-    """Small common base for unturtle evaluation helpers."""
+class BaseEvaluator(ABC):
+    """Abstract base class for unturtle evaluation helpers."""
 
     def __init__(
         self,
@@ -69,5 +70,6 @@ class BaseEvaluator:
             if was_training:
                 self.model.train()
 
+    @abstractmethod
     def evaluate(self, *_args: Any, **_kwargs: Any) -> dict[str, float]:
-        raise NotImplementedError
+        ...

--- a/unturtle/eval/base.py
+++ b/unturtle/eval/base.py
@@ -1,0 +1,73 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any, Iterator
+
+import torch
+from torch.utils.data import DataLoader
+
+
+class BaseEvaluator:
+    """Small common base for unturtle evaluation helpers."""
+
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        tokenizer: Any | None = None,
+        device: torch.device | str | None = None,
+    ) -> None:
+        self.model = model
+        self.tokenizer = tokenizer
+        if device is None:
+            first_param = next(iter(model.parameters()), None)
+            device = first_param.device if first_param is not None else torch.device("cpu")
+        self.device = torch.device(device)
+
+    def _make_dataloader(
+        self,
+        dataset: Any,
+        batch_size: int,
+        collate_fn: Any | None = None,
+    ) -> DataLoader:
+        return DataLoader(dataset, batch_size=batch_size, collate_fn=collate_fn)
+
+    def _move_to_device(self, value: Any) -> Any:
+        if isinstance(value, torch.Tensor):
+            return value.to(self.device)
+        if isinstance(value, dict):
+            return {k: self._move_to_device(v) for k, v in value.items()}
+        if isinstance(value, (list, tuple)):
+            converted = [self._move_to_device(v) for v in value]
+            return type(value)(converted)
+        return value
+
+    def _metric_key(self, prefix: str, name: str) -> str:
+        return f"{prefix}_{name}" if prefix else name
+
+    @contextmanager
+    def evaluation_mode(self) -> Iterator[None]:
+        was_training = self.model.training
+        self.model.eval()
+        try:
+            with torch.no_grad():
+                yield
+        finally:
+            if was_training:
+                self.model.train()
+
+    def evaluate(self, *_args: Any, **_kwargs: Any) -> dict[str, float]:
+        raise NotImplementedError

--- a/unturtle/eval/diffusion.py
+++ b/unturtle/eval/diffusion.py
@@ -28,7 +28,22 @@ from .base import BaseEvaluator
 
 
 class MaskedDiffusionEvaluator(BaseEvaluator):
-    """Evaluate masked-diffusion loss metrics on a validation dataset."""
+    """Evaluate masked-diffusion loss metrics on a validation dataset.
+
+    Metrics reported by :meth:`evaluate`:
+
+    - ``eval_loss``: weighted training loss (may use timestep/scheduler weights).
+    - ``eval_masked_token_nll``: unweighted per-maskable-token NLL, matching the
+      MDLM trainer normalization ``token_nll / maskable_mask.sum()`` (mdlm.py L200).
+    - ``eval_perplexity``: ``exp(eval_masked_token_nll)``.
+    - ``eval_mask_rate``: fraction of maskable tokens that were actually masked.
+
+    Note: ``eval_masked_token_nll`` is the *training-objective* NLL evaluated on the
+    validation set with random masking.  It is **not** the MDLM Monte Carlo
+    log-likelihood estimator (which corrects for mask probability via
+    ``CE / p_mask[mask_indices]``).  For a direct comparison with MDLM eval metrics,
+    use a dedicated Monte Carlo evaluator.
+    """
 
     def __init__(
         self,

--- a/unturtle/eval/diffusion.py
+++ b/unturtle/eval/diffusion.py
@@ -1,0 +1,160 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import torch
+
+from unturtle.kernels.masked_diffusion_loss import fast_masked_diffusion_loss
+from unturtle.diffusion.collator import MaskedDiffusionDataCollator
+from unturtle.diffusion.packed_collator import PackedMaskedDiffusionDataCollator
+from unturtle.diffusion.schedulers import LinearAlphaScheduler, make_alpha_scheduler
+
+from .base import BaseEvaluator
+
+
+class MaskedDiffusionEvaluator(BaseEvaluator):
+    """Evaluate masked-diffusion loss metrics on a validation dataset."""
+
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        tokenizer: Any,
+        data_collator: Any | None = None,
+        loss_weight_type: str = "uniform",
+        alpha_scheduler: Any | None = None,
+        time_epsilon: float = 1e-3,
+        completion_only: bool = True,
+        metric_key_prefix: str = "eval",
+        device: torch.device | str | None = None,
+    ) -> None:
+        super().__init__(model=model, tokenizer=tokenizer, device=device)
+        if isinstance(alpha_scheduler, str):
+            alpha_scheduler = make_alpha_scheduler(alpha_scheduler)
+        self.alpha_scheduler = alpha_scheduler or LinearAlphaScheduler()
+        self.loss_weight_type = loss_weight_type
+        self.time_epsilon = time_epsilon
+        self.completion_only = completion_only
+        self.metric_key_prefix = metric_key_prefix
+        mask_token_id = getattr(tokenizer, "mask_token_id", None)
+        if mask_token_id is None:
+            mask_token_id = getattr(getattr(model, "config", None), "mask_token_id", None)
+        self.data_collator = data_collator or MaskedDiffusionDataCollator(
+            tokenizer=tokenizer,
+            scheduler=self.alpha_scheduler,
+            mask_token_id=mask_token_id,
+            time_epsilon=time_epsilon,
+            completion_only=completion_only,
+        )
+        if isinstance(self.data_collator, PackedMaskedDiffusionDataCollator) and self.loss_weight_type != "uniform":
+            raise ValueError(
+                "PackedMaskedDiffusionDataCollator is not supported for diffusion evaluation with "
+                "loss_weight_type='timestep' or 'scheduler'. Use uniform weighting or an "
+                "unpacked MaskedDiffusionDataCollator."
+            )
+
+    def _build_loss_weights(
+        self,
+        timesteps: torch.Tensor,
+        logits: torch.Tensor,
+    ) -> torch.Tensor | None:
+        if self.loss_weight_type == "uniform":
+            return None
+
+        device = logits.device
+        t = timesteps.to(device)
+
+        if self.loss_weight_type == "timestep":
+            return 1.0 / t.clamp_min(1e-6)
+
+        if self.loss_weight_type == "scheduler":
+            weights = self.alpha_scheduler.weight(t)
+            if not isinstance(weights, torch.Tensor):
+                weights = torch.tensor(weights, device=device)
+            return weights.to(device)
+
+        raise ValueError(
+            f"Unknown loss_weight_type '{self.loss_weight_type}'. "
+            "Choose from: 'uniform', 'timestep', 'scheduler'."
+        )
+
+    def evaluate(
+        self,
+        dataset: Any,
+        batch_size: int = 1,
+        max_batches: int | None = None,
+    ) -> dict[str, float]:
+        dataloader = self._make_dataloader(
+            dataset,
+            batch_size=batch_size,
+            collate_fn=self.data_collator,
+        )
+
+        total_loss = 0.0
+        total_unweighted_nll = 0.0
+        total_maskable = 0
+        total_masked = 0
+        total_batches = 0
+
+        with self.evaluation_mode():
+            for batch in dataloader:
+                if max_batches is not None and total_batches >= max_batches:
+                    break
+
+                batch = self._move_to_device(batch)
+                labels: torch.Tensor = batch.pop("labels")
+                diffusion_mask: torch.Tensor = batch.pop("diffusion_mask")
+                timesteps: torch.Tensor = batch.pop("timesteps")
+
+                outputs = self.model(**batch)
+                logits: torch.Tensor = outputs.logits
+                loss_weights = self._build_loss_weights(timesteps, logits)
+                loss = fast_masked_diffusion_loss(
+                    logits=logits,
+                    labels=labels,
+                    diffusion_mask=diffusion_mask,
+                    loss_weights=loss_weights,
+                )
+                unweighted_nll = fast_masked_diffusion_loss(
+                    logits=logits,
+                    labels=labels,
+                    diffusion_mask=diffusion_mask,
+                    loss_weights=None,
+                )
+
+                maskable = int((labels != -100).sum().item())
+                masked = int(diffusion_mask.sum().item())
+                total_loss += float(loss.item()) * max(maskable, 1)
+                total_unweighted_nll += float(unweighted_nll.item()) * max(maskable, 1)
+                total_maskable += maskable
+                total_masked += masked
+                total_batches += 1
+
+        denom = max(total_maskable, 1)
+        avg_loss = total_loss / denom
+        avg_unweighted_nll = total_unweighted_nll / denom
+        perplexity = math.exp(avg_unweighted_nll) if avg_unweighted_nll < 80 else float("inf")
+        mask_rate = float(total_masked) / denom
+        prefix = self.metric_key_prefix
+
+        return {
+            self._metric_key(prefix, "loss"): avg_loss,
+            self._metric_key(prefix, "masked_token_nll"): avg_unweighted_nll,
+            self._metric_key(prefix, "perplexity"): perplexity,
+            self._metric_key(prefix, "mask_rate"): mask_rate,
+            self._metric_key(prefix, "num_batches"): float(total_batches),
+        }

--- a/unturtle/eval/generation.py
+++ b/unturtle/eval/generation.py
@@ -1,0 +1,154 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from .base import BaseEvaluator
+
+
+class GenerationEvaluator(BaseEvaluator):
+    """Evaluate diffusion generation against token-level references."""
+
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        tokenizer: Any,
+        metric_key_prefix: str = "gen",
+        device: torch.device | str | None = None,
+    ) -> None:
+        super().__init__(model=model, tokenizer=tokenizer, device=device)
+        self.metric_key_prefix = metric_key_prefix
+
+    @staticmethod
+    def _to_long_tensor(value: Any) -> torch.Tensor:
+        if isinstance(value, torch.Tensor):
+            return value.to(dtype=torch.long)
+        return torch.tensor(value, dtype=torch.long)
+
+    def _extract_prompt_and_reference(
+        self,
+        example: dict[str, Any],
+    ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
+        input_ids = self._to_long_tensor(example["input_ids"])
+        attention_mask = None
+        valid_positions = None
+        if "attention_mask" in example and example["attention_mask"] is not None:
+            attention_mask = self._to_long_tensor(example["attention_mask"])
+            valid_positions = attention_mask.bool()
+            input_ids = input_ids[valid_positions]
+            attention_mask = attention_mask[valid_positions]
+
+        if "references" in example and example["references"] is not None:
+            return input_ids, self._to_long_tensor(example["references"]), attention_mask
+
+        if "labels" in example and example["labels"] is not None:
+            labels = self._to_long_tensor(example["labels"])
+            if valid_positions is not None:
+                labels = labels[valid_positions]
+
+            supervised_positions = (labels != -100).nonzero(as_tuple=False).flatten()
+            if supervised_positions.numel() == 0:
+                return input_ids, None, attention_mask
+
+            start = int(supervised_positions[0].item())
+            end = int(supervised_positions[-1].item()) + 1
+            return input_ids[:start], labels[start:end], attention_mask[:start] if attention_mask is not None else None
+
+        return input_ids, None, attention_mask
+
+    def _generate_one(
+        self,
+        prompt_ids: torch.Tensor,
+        generation_config: Any | None,
+        reference_ids: torch.Tensor | None,
+        attention_mask: torch.Tensor | None,
+    ) -> torch.Tensor:
+        prompt_ids = prompt_ids.unsqueeze(0).to(self.device)
+        generation_kwargs: dict[str, Any] = {}
+        if generation_config is not None:
+            if isinstance(generation_config, dict):
+                generation_kwargs.update(generation_config)
+            else:
+                generation_kwargs["generation_config"] = generation_config
+
+        if "max_length" not in generation_kwargs and "generation_config" not in generation_kwargs:
+            target_len = int(reference_ids.numel()) if reference_ids is not None else 1
+            generation_kwargs["max_length"] = prompt_ids.shape[1] + target_len
+        if attention_mask is not None:
+            generation_kwargs["attention_mask"] = attention_mask.unsqueeze(0).to(self.device)
+
+        diffusion_generate = getattr(self.model, "diffusion_generate", None)
+        if callable(diffusion_generate):
+            sequences = diffusion_generate(prompt_ids, **generation_kwargs)
+        else:
+            generate = getattr(self.model, "generate")
+            sequences = generate(prompt_ids, **generation_kwargs)
+
+        if hasattr(sequences, "sequences"):
+            sequences = sequences.sequences
+        return sequences[0].detach().cpu()
+
+    def evaluate(
+        self,
+        dataset: Any,
+        generation_config: Any | None = None,
+        batch_size: int = 1,
+        max_batches: int | None = None,
+    ) -> dict[str, float]:
+        del batch_size  # current implementation evaluates one prompt at a time
+
+        total_examples = 0
+        exact_matches = 0
+        correct_tokens = 0
+        total_reference_tokens = 0
+
+        with self.evaluation_mode():
+            for idx, example in enumerate(dataset):
+                if max_batches is not None and idx >= max_batches:
+                    break
+
+                prompt_ids, reference_ids, attention_mask = self._extract_prompt_and_reference(example)
+                generated = self._generate_one(prompt_ids, generation_config, reference_ids, attention_mask)
+
+                if reference_ids is None or reference_ids.numel() == 0:
+                    total_examples += 1
+                    continue
+
+                prompt_len = int(prompt_ids.numel())
+                target_len = int(reference_ids.numel())
+                generated_suffix = generated[prompt_len : prompt_len + target_len]
+
+                if generated_suffix.numel() < target_len:
+                    padded = torch.full((target_len,), -1, dtype=torch.long)
+                    padded[: generated_suffix.numel()] = generated_suffix
+                    generated_suffix = padded
+
+                matches = generated_suffix.eq(reference_ids.cpu())
+                exact_matches += int(matches.all().item())
+                correct_tokens += int(matches.sum().item())
+                total_reference_tokens += target_len
+                total_examples += 1
+
+        prefix = self.metric_key_prefix
+        denom_examples = max(total_examples, 1)
+        denom_tokens = max(total_reference_tokens, 1)
+        return {
+            self._metric_key(prefix, "exact_match"): exact_matches / denom_examples,
+            self._metric_key(prefix, "token_accuracy"): correct_tokens / denom_tokens,
+            self._metric_key(prefix, "num_examples"): float(total_examples),
+        }

--- a/unturtle/eval/generation.py
+++ b/unturtle/eval/generation.py
@@ -107,11 +107,8 @@ class GenerationEvaluator(BaseEvaluator):
         self,
         dataset: Any,
         generation_config: Any | None = None,
-        batch_size: int = 1,
-        max_batches: int | None = None,
+        max_examples: int | None = None,
     ) -> dict[str, float]:
-        del batch_size  # current implementation evaluates one prompt at a time
-
         total_examples = 0
         exact_matches = 0
         correct_tokens = 0
@@ -119,14 +116,14 @@ class GenerationEvaluator(BaseEvaluator):
 
         with self.evaluation_mode():
             for idx, example in enumerate(dataset):
-                if max_batches is not None and idx >= max_batches:
+                if max_examples is not None and idx >= max_examples:
                     break
 
                 prompt_ids, reference_ids, attention_mask = self._extract_prompt_and_reference(example)
                 generated = self._generate_one(prompt_ids, generation_config, reference_ids, attention_mask)
 
                 if reference_ids is None or reference_ids.numel() == 0:
-                    total_examples += 1
+                    # No reference to score — skip without counting
                     continue
 
                 prompt_len = int(prompt_ids.numel())


### PR DESCRIPTION
## Summary

- `unturtle/eval/` パッケージ新設: `BaseEvaluator`, `MaskedDiffusionEvaluator`, `GenerationEvaluator`
- `DiffusionTrainer` に `build_diffusion_evaluator` / `evaluate_diffusion` / `build_generation_evaluator` / `evaluate_generation` を追加
- `MaskedDiffusionDataCollator`: 可変長バッチの completion-only labels を正しくパディング (padding_side 対応)
- `PackedMaskedDiffusionDataCollator`: maskable labels を常に保持; flash_attn 有効時も `block_attention_mask` を emit
- collator の label semantics を `fused_masked_diffusion_loss` の分母 (`n_maskable`) と整合
- packed collator + non-uniform loss weighting を evaluator 直使用でも reject するガードを追加
- `DiffusionTrainer` の double normalization を除去

## Test plan

- [ ] `python -m pytest tests/eval/test_evaluators.py -v` — 全テスト通過
- [ ] `python -m pytest tests/diffusion/test_integration.py tests/diffusion/test_packed_collator.py -v` — 全テスト通過
- [ ] `python -m pytest tests/diffusion/test_masked_diffusion_loss.py -v` — collator expectation 更新を確認
- [ ] `MaskedDiffusionEvaluator` が eval_loss / eval_masked_token_nll / eval_perplexity / eval_mask_rate を正しく返すことを確認
- [ ] `GenerationEvaluator` が exact_match / token_accuracy を返すことを確認
- [ ] 左パディング入力 + completion-only labels の generation 評価が正しく動作することを確認

Closes #55