### PR TITLE
🐛 fix(a2d): correct CUDA RoPE path for packed embeddings (#49)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,7 @@ These rules apply to `_patch_a2d_peft`, `_patch_dream_peft`, `_patch_llada_peft`
 | prompt/full tokenization mismatch in completion-only datasets | prompt tokens become maskable or completion boundary shifts for override checkpoints | Build prompt/completion ids with the same tokenizer settings (e.g. both `add_special_tokens=False`) and concatenate them explicitly |
 | `LLaDAModelLM` lacks `all_tied_weights_keys` (Hub class) | `AttributeError: 'LLaDAModelLM' has no attribute 'all_tied_weights_keys'` during 4-bit load | `FastDiffusionModel._load_model_auto` routes `model_type="llada"` to unturtle's own class; unturtle class calls `self.post_init()` and accepts `tie_weights(**kwargs)` |
 | `load_in_4bit` without `device_map` OOM on crowded GPU | OOM caught silently → falls through to Hub class → `all_tied_weights_keys` error | `FastDiffusionModel.from_pretrained` sets `device_map="auto"` automatically when `load_in_4bit=True` |
+| A2D CUDA RoPE with pre-indexed `position_embeddings` | Packed/non-monotonic `position_ids` produce wrong CUDA outputs despite CPU fallback passing | `self.rotary_emb(hidden_states, position_ids)` already returns cos/sin aligned to `position_ids`; in `A2DAttention_fast_forward` flatten `(B,L,D)` cos/sin to `(B*L,D)` and pass flat row indices `arange(B*L)` instead of reusing `position_ids` |
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -793,3 +793,35 @@ loss = loss.sum() / (inputs["input_ids"].numel() - num_prompt_tokens)
 mask_rate=0.15 のとき旧実装は MDLM より約 6.7 倍大きい loss 値を出していた。
 `n_maskable` に変更したことで LR を参照実装からそのまま移植できるようになった。
 
+### 16. A2D の CUDA RoPE は `position_ids` を再利用してはいけない
+
+`A2DLlamaModel.forward` / `A2DQwen2Model.forward` / `A2DQwen3Model.forward` では
+`self.rotary_emb(hidden_states, position_ids)` を先に呼び、**すでに `position_ids` に整列済みの**
+`cos, sin` を `position_embeddings` として `A2DAttention_fast_forward` に渡す。
+
+そのため CUDA 側で `fast_rope_embedding(Q, K, cos, sin, position_ids)` を呼ぶと、
+packed sequence のような非単調/リセットされた `position_ids` で **二重に index されて誤った RoPE** になる。
+CPU fallback の `_rotate_half_rope` は与えられた `cos/sin` をそのまま適用するため、この不整合に気づきにくい。
+
+```python
+# NG: pre-indexed cos/sin に対して position_ids を再度渡す
+cos, sin = position_embeddings  # already aligned to position_ids
+Q, K = fast_rope_embedding(Q, K, cos, sin, position_ids)
+
+# OK: Triton indexed pathを使うなら (B,L,D) -> (B*L,D) に flatten し、
+# row selector は position_ids ではなく flat row index を渡す
+cos, sin = position_embeddings
+cos = cos.reshape(-1, cos.shape[-1])
+sin = sin.reshape(-1, sin.shape[-1])
+rope_indices = torch.arange(bsz * q_len, device=Q.device, dtype=torch.long)
+Q, K = fast_rope_embedding(Q, K, cos, sin, rope_indices)
+```
+
+**症状**:
+- `position_ids = [0,1,0,1,2,3,...]` のような packed/reset パターンで CUDA だけ出力が壊れる
+- 単純な `[0,1,2,3,...]` テストは通るため見逃しやすい
+
+**テスト方針**:
+- repeated/reset された `position_ids` を使う
+- B=2 以上のケースも追加して、バッチをまたいだ flatten row index も検証する
+

--- a/tests/models/test_a2d.py
+++ b/tests/models/test_a2d.py
@@ -580,15 +580,31 @@ def _make_cos_sin(
     dtype: torch.dtype = torch.float32,
     device: str = "cpu",
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Build cos/sin of shape (B, L, head_dim) compatible with _rotate_half_rope."""
+    """Build sequential cos/sin of shape (B, L, head_dim)."""
+    position_ids = torch.arange(L, dtype=torch.long).unsqueeze(0).expand(B, -1)
+    return _make_cos_sin_from_position_ids(
+        position_ids=position_ids,
+        head_dim=head_dim,
+        dtype=dtype,
+        device=device,
+    )
+
+
+
+def _make_cos_sin_from_position_ids(
+    position_ids: torch.Tensor,
+    head_dim: int,
+    dtype: torch.dtype = torch.float32,
+    device: str = "cpu",
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build cos/sin of shape (B, L, head_dim) for arbitrary position_ids."""
     theta = 1.0 / (
         10000 ** (torch.arange(0, head_dim, 2, dtype=torch.float32) / head_dim)
     )
-    pos = torch.arange(L, dtype=torch.float32)
-    freqs = torch.outer(pos, theta)               # (L, head_dim // 2)
-    emb = torch.cat([freqs, freqs], dim=-1)        # (L, head_dim)
-    cos = emb.cos().unsqueeze(0).expand(B, -1, -1).to(dtype=dtype).to(device)
-    sin = emb.sin().unsqueeze(0).expand(B, -1, -1).to(dtype=dtype).to(device)
+    freqs = position_ids[..., None].to(torch.float32) * theta.view(1, 1, -1)
+    emb = torch.cat([freqs, freqs], dim=-1)
+    cos = emb.cos().to(dtype=dtype).to(device)
+    sin = emb.sin().to(dtype=dtype).to(device)
     return cos, sin
 
 
@@ -617,20 +633,18 @@ class TestA2DRoPE:
         )
 
     def test_l2_norm_preserved_with_position_ids(self):
-        """L2 norm must be preserved even when position_ids is passed explicitly.
-
-        Note: ``_rotate_half_rope`` currently ignores ``position_ids`` and applies
-        the full cos/sin slice directly.  Sequential position_ids=[0,1,...,L-1]
-        therefore yields the same result as position_ids=None.
-        """
+        """RoPE norm preservation must hold for packed-style repeated position_ids."""
         from unturtle.models.a2d._fast_forward import _rotate_half_rope
 
         B, n_heads, L, head_dim = 2, 4, 8, 16
         torch.manual_seed(1)
         Q = torch.randn(B, n_heads, L, head_dim)
         K = torch.randn(B, n_heads, L, head_dim)
-        cos, sin = _make_cos_sin(B, L, head_dim)
-        position_ids = torch.arange(L).unsqueeze(0).expand(B, -1).long()  # (B, L)
+        position_ids: torch.LongTensor = torch.tensor(
+            [[0, 1, 2, 3, 0, 1, 2, 3], [0, 0, 1, 1, 2, 2, 3, 3]],
+            dtype=torch.long,
+        )
+        cos, sin = _make_cos_sin_from_position_ids(position_ids, head_dim)
 
         Q_out, K_out = _rotate_half_rope(Q, K, cos, sin, position_ids=position_ids)
 
@@ -640,12 +654,6 @@ class TestA2DRoPE:
         torch.testing.assert_close(
             K_out.norm(dim=-1), K.norm(dim=-1), atol=1e-5, rtol=1e-5,
         )
-
-        # Sequential position_ids must produce the same result as position_ids=None
-        # (documents current pass-through behavior; will catch future regressions)
-        Q_out_none, K_out_none = _rotate_half_rope(Q, K, cos, sin, position_ids=None)
-        torch.testing.assert_close(Q_out, Q_out_none)
-        torch.testing.assert_close(K_out, K_out_none)
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
     def test_cpu_matches_cuda_no_position_ids(self):
@@ -684,7 +692,7 @@ class TestA2DRoPE:
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
     def test_cpu_matches_cuda_with_position_ids(self):
-        """CPU _rotate_half_rope must match CUDA fast_rope_embedding (with position_ids)."""
+        """CPU fallback must match indexed CUDA RoPE for packed-style position_ids."""
         from unturtle.models.a2d._fast_forward import _rotate_half_rope
 
         try:
@@ -696,20 +704,20 @@ class TestA2DRoPE:
         torch.manual_seed(3)
         Q_cpu = torch.randn(B, n_heads, L, head_dim)
         K_cpu = torch.randn(B, n_heads, L, head_dim)
-        cos_cpu, sin_cpu = _make_cos_sin(B, L, head_dim)
-        position_ids = torch.arange(L).unsqueeze(0).long()  # (1, L)
+        position_ids: torch.LongTensor = torch.tensor(
+            [[0, 1, 2, 3, 0, 1, 2, 3]], dtype=torch.long
+        )
+        cos_cpu, sin_cpu = _make_cos_sin_from_position_ids(position_ids, head_dim)
 
         Q_out_cpu, K_out_cpu = _rotate_half_rope(
             Q_cpu, K_cpu, cos_cpu, sin_cpu, position_ids=position_ids
         )
 
-        # For the indexed CUDA path, pass cos/sin as (L, head_dim) and
-        # rope_embedding_indices as flat (B*L,) = (L,) for B=1.
         Q_cuda = Q_cpu.cuda().to(torch.bfloat16)
         K_cuda = K_cpu.cuda().to(torch.bfloat16)
-        cos_cuda = cos_cpu.squeeze(0).cuda().to(torch.bfloat16)   # (L, head_dim)
+        cos_cuda = cos_cpu.squeeze(0).cuda().to(torch.bfloat16)
         sin_cuda = sin_cpu.squeeze(0).cuda().to(torch.bfloat16)
-        rope_indices = position_ids.reshape(-1).cuda()             # (L,)
+        rope_indices = position_ids.reshape(-1).cuda()
 
         Q_out_cuda, K_out_cuda = fast_rope_embedding(
             Q_cuda, K_cuda, cos_cuda, sin_cuda,

--- a/tests/models/test_a2d.py
+++ b/tests/models/test_a2d.py
@@ -566,3 +566,159 @@ class TestA2DGeneration:
                 max_length=L + 1,
             )
         assert out.shape == (B, L + 1)
+
+
+# ---------------------------------------------------------------------------
+# RoPE unit tests
+# ---------------------------------------------------------------------------
+
+
+def _make_cos_sin(
+    B: int,
+    L: int,
+    head_dim: int,
+    dtype: torch.dtype = torch.float32,
+    device: str = "cpu",
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build cos/sin of shape (B, L, head_dim) compatible with _rotate_half_rope."""
+    theta = 1.0 / (
+        10000 ** (torch.arange(0, head_dim, 2, dtype=torch.float32) / head_dim)
+    )
+    pos = torch.arange(L, dtype=torch.float32)
+    freqs = torch.outer(pos, theta)               # (L, head_dim // 2)
+    emb = torch.cat([freqs, freqs], dim=-1)        # (L, head_dim)
+    cos = emb.cos().unsqueeze(0).expand(B, -1, -1).to(dtype=dtype).to(device)
+    sin = emb.sin().unsqueeze(0).expand(B, -1, -1).to(dtype=dtype).to(device)
+    return cos, sin
+
+
+class TestA2DRoPE:
+    """Unit tests for ``_rotate_half_rope`` (CPU RoPE fallback in A2D fast forward)."""
+
+    def test_l2_norm_preserved_no_position_ids(self):
+        """RoPE rotation must be an isometry: per-vector L2 norm is preserved."""
+        from unturtle.models.a2d._fast_forward import _rotate_half_rope
+
+        B, n_heads, L, head_dim = 2, 4, 8, 16
+        torch.manual_seed(0)
+        Q = torch.randn(B, n_heads, L, head_dim)
+        K = torch.randn(B, n_heads, L, head_dim)
+        cos, sin = _make_cos_sin(B, L, head_dim)
+
+        Q_out, K_out = _rotate_half_rope(Q, K, cos, sin, position_ids=None)
+
+        assert Q_out.shape == Q.shape
+        assert K_out.shape == K.shape
+        torch.testing.assert_close(
+            Q_out.norm(dim=-1), Q.norm(dim=-1), atol=1e-5, rtol=1e-5,
+        )
+        torch.testing.assert_close(
+            K_out.norm(dim=-1), K.norm(dim=-1), atol=1e-5, rtol=1e-5,
+        )
+
+    def test_l2_norm_preserved_with_position_ids(self):
+        """L2 norm must be preserved even when position_ids is passed explicitly.
+
+        Note: ``_rotate_half_rope`` currently ignores ``position_ids`` and applies
+        the full cos/sin slice directly.  Sequential position_ids=[0,1,...,L-1]
+        therefore yields the same result as position_ids=None.
+        """
+        from unturtle.models.a2d._fast_forward import _rotate_half_rope
+
+        B, n_heads, L, head_dim = 2, 4, 8, 16
+        torch.manual_seed(1)
+        Q = torch.randn(B, n_heads, L, head_dim)
+        K = torch.randn(B, n_heads, L, head_dim)
+        cos, sin = _make_cos_sin(B, L, head_dim)
+        position_ids = torch.arange(L).unsqueeze(0).expand(B, -1).long()  # (B, L)
+
+        Q_out, K_out = _rotate_half_rope(Q, K, cos, sin, position_ids=position_ids)
+
+        torch.testing.assert_close(
+            Q_out.norm(dim=-1), Q.norm(dim=-1), atol=1e-5, rtol=1e-5,
+        )
+        torch.testing.assert_close(
+            K_out.norm(dim=-1), K.norm(dim=-1), atol=1e-5, rtol=1e-5,
+        )
+
+        # Sequential position_ids must produce the same result as position_ids=None
+        # (documents current pass-through behavior; will catch future regressions)
+        Q_out_none, K_out_none = _rotate_half_rope(Q, K, cos, sin, position_ids=None)
+        torch.testing.assert_close(Q_out, Q_out_none)
+        torch.testing.assert_close(K_out, K_out_none)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+    def test_cpu_matches_cuda_no_position_ids(self):
+        """CPU _rotate_half_rope must match CUDA fast_rope_embedding (no position_ids)."""
+        from unturtle.models.a2d._fast_forward import _rotate_half_rope
+
+        try:
+            from unsloth.kernels.rope_embedding import fast_rope_embedding
+        except ImportError:
+            pytest.skip("unsloth.kernels.rope_embedding not available")
+
+        B, n_heads, L, head_dim = 1, 4, 8, 32
+        torch.manual_seed(2)
+        Q_cpu = torch.randn(B, n_heads, L, head_dim)
+        K_cpu = torch.randn(B, n_heads, L, head_dim)
+        cos_cpu, sin_cpu = _make_cos_sin(B, L, head_dim)
+
+        Q_out_cpu, K_out_cpu = _rotate_half_rope(Q_cpu, K_cpu, cos_cpu, sin_cpu)
+
+        # fast_rope_embedding expects cos/sin as (1, L, head_dim) or (L, head_dim);
+        # it calls .squeeze() internally so (1, L, head_dim) → (L, head_dim).
+        Q_cuda = Q_cpu.cuda().to(torch.bfloat16)
+        K_cuda = K_cpu.cuda().to(torch.bfloat16)
+        cos_cuda = cos_cpu.cuda().to(torch.bfloat16)   # (1, L, head_dim)
+        sin_cuda = sin_cpu.cuda().to(torch.bfloat16)
+
+        Q_out_cuda, K_out_cuda = fast_rope_embedding(Q_cuda, K_cuda, cos_cuda, sin_cuda)
+
+        # Tolerance is relaxed to 1e-2 because CUDA path runs in bfloat16
+        torch.testing.assert_close(
+            Q_out_cuda.float().cpu(), Q_out_cpu, atol=1e-2, rtol=1e-2,
+        )
+        torch.testing.assert_close(
+            K_out_cuda.float().cpu(), K_out_cpu, atol=1e-2, rtol=1e-2,
+        )
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+    def test_cpu_matches_cuda_with_position_ids(self):
+        """CPU _rotate_half_rope must match CUDA fast_rope_embedding (with position_ids)."""
+        from unturtle.models.a2d._fast_forward import _rotate_half_rope
+
+        try:
+            from unsloth.kernels.rope_embedding import fast_rope_embedding
+        except ImportError:
+            pytest.skip("unsloth.kernels.rope_embedding not available")
+
+        B, n_heads, L, head_dim = 1, 4, 8, 32
+        torch.manual_seed(3)
+        Q_cpu = torch.randn(B, n_heads, L, head_dim)
+        K_cpu = torch.randn(B, n_heads, L, head_dim)
+        cos_cpu, sin_cpu = _make_cos_sin(B, L, head_dim)
+        position_ids = torch.arange(L).unsqueeze(0).long()  # (1, L)
+
+        Q_out_cpu, K_out_cpu = _rotate_half_rope(
+            Q_cpu, K_cpu, cos_cpu, sin_cpu, position_ids=position_ids
+        )
+
+        # For the indexed CUDA path, pass cos/sin as (L, head_dim) and
+        # rope_embedding_indices as flat (B*L,) = (L,) for B=1.
+        Q_cuda = Q_cpu.cuda().to(torch.bfloat16)
+        K_cuda = K_cpu.cuda().to(torch.bfloat16)
+        cos_cuda = cos_cpu.squeeze(0).cuda().to(torch.bfloat16)   # (L, head_dim)
+        sin_cuda = sin_cpu.squeeze(0).cuda().to(torch.bfloat16)
+        rope_indices = position_ids.reshape(-1).cuda()             # (L,)
+
+        Q_out_cuda, K_out_cuda = fast_rope_embedding(
+            Q_cuda, K_cuda, cos_cuda, sin_cuda,
+            rope_embedding_indices=rope_indices,
+        )
+
+        torch.testing.assert_close(
+            Q_out_cuda.float().cpu(), Q_out_cpu, atol=1e-2, rtol=1e-2,
+        )
+        torch.testing.assert_close(
+            K_out_cuda.float().cpu(), K_out_cpu, atol=1e-2, rtol=1e-2,
+        )

--- a/tests/models/test_a2d.py
+++ b/tests/models/test_a2d.py
@@ -692,7 +692,7 @@ class TestA2DRoPE:
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
     def test_cpu_matches_cuda_with_position_ids(self):
-        """CPU fallback must match indexed CUDA RoPE for packed-style position_ids."""
+        """CPU fallback must match CUDA RoPE for packed-style position_ids."""
         from unturtle.models.a2d._fast_forward import _rotate_half_rope
 
         try:
@@ -705,7 +705,7 @@ class TestA2DRoPE:
         Q_cpu = torch.randn(B, n_heads, L, head_dim)
         K_cpu = torch.randn(B, n_heads, L, head_dim)
         position_ids: torch.LongTensor = torch.tensor(
-            [[0, 1, 2, 3, 0, 1, 2, 3]], dtype=torch.long
+            [[0, 1, 0, 1, 2, 3, 4, 5]], dtype=torch.long
         )
         cos_cpu, sin_cpu = _make_cos_sin_from_position_ids(position_ids, head_dim)
 
@@ -715,13 +715,11 @@ class TestA2DRoPE:
 
         Q_cuda = Q_cpu.cuda().to(torch.bfloat16)
         K_cuda = K_cpu.cuda().to(torch.bfloat16)
-        cos_cuda = cos_cpu.squeeze(0).cuda().to(torch.bfloat16)
-        sin_cuda = sin_cpu.squeeze(0).cuda().to(torch.bfloat16)
-        rope_indices = position_ids.reshape(-1).cuda()
+        cos_cuda = cos_cpu.cuda().to(torch.bfloat16)
+        sin_cuda = sin_cpu.cuda().to(torch.bfloat16)
 
         Q_out_cuda, K_out_cuda = fast_rope_embedding(
             Q_cuda, K_cuda, cos_cuda, sin_cuda,
-            rope_embedding_indices=rope_indices,
         )
 
         torch.testing.assert_close(
@@ -729,4 +727,75 @@ class TestA2DRoPE:
         )
         torch.testing.assert_close(
             K_out_cuda.float().cpu(), K_out_cpu, atol=1e-2, rtol=1e-2,
+        )
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+    def test_flattened_preindexed_cuda_path_matches_cpu(self):
+        """Flattened pre-indexed cos/sin with flat row indices must match CPU fallback."""
+        from unturtle.models.a2d._fast_forward import _rotate_half_rope
+
+        try:
+            from unsloth.kernels.rope_embedding import fast_rope_embedding
+        except ImportError:
+            pytest.skip("unsloth.kernels.rope_embedding not available")
+
+        B, n_heads, L, head_dim = 2, 4, 8, 32
+        torch.manual_seed(4)
+        Q_cpu = torch.randn(B, n_heads, L, head_dim)
+        K_cpu = torch.randn(B, n_heads, L, head_dim)
+        position_ids: torch.LongTensor = torch.tensor(
+            [[0, 1, 2, 3, 0, 1, 2, 3], [0, 0, 1, 1, 2, 2, 3, 3]],
+            dtype=torch.long,
+        )
+        cos_cpu, sin_cpu = _make_cos_sin_from_position_ids(position_ids, head_dim)
+
+        Q_expected, K_expected = _rotate_half_rope(
+            Q_cpu, K_cpu, cos_cpu, sin_cpu, position_ids=position_ids
+        )
+
+        flat_indices = torch.arange(B * L, dtype=torch.long, device="cuda")
+        Q_out_cuda, K_out_cuda = fast_rope_embedding(
+            Q_cpu.cuda().to(torch.bfloat16),
+            K_cpu.cuda().to(torch.bfloat16),
+            cos_cpu.reshape(B * L, head_dim).cuda().to(torch.bfloat16),
+            sin_cpu.reshape(B * L, head_dim).cuda().to(torch.bfloat16),
+            rope_embedding_indices=flat_indices,
+        )
+
+        torch.testing.assert_close(
+            Q_out_cuda.float().cpu(), Q_expected, atol=1e-2, rtol=1e-2,
+        )
+        torch.testing.assert_close(
+            K_out_cuda.float().cpu(), K_expected, atol=1e-2, rtol=1e-2,
+        )
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+    def test_broadcasted_cos_sin_cuda_path_matches_cpu(self):
+        """Broadcasted (1, L, D) cos/sin must stay on the non-indexed CUDA path."""
+        from unturtle.models.a2d._fast_forward import _rotate_half_rope
+
+        try:
+            from unsloth.kernels.rope_embedding import fast_rope_embedding
+        except ImportError:
+            pytest.skip("unsloth.kernels.rope_embedding not available")
+
+        B, n_heads, L, head_dim = 2, 4, 8, 32
+        torch.manual_seed(5)
+        Q_cpu = torch.randn(B, n_heads, L, head_dim)
+        K_cpu = torch.randn(B, n_heads, L, head_dim)
+        cos_cpu, sin_cpu = _make_cos_sin(1, L, head_dim)
+
+        Q_expected, K_expected = _rotate_half_rope(Q_cpu, K_cpu, cos_cpu, sin_cpu)
+        Q_out_cuda, K_out_cuda = fast_rope_embedding(
+            Q_cpu.cuda().to(torch.bfloat16),
+            K_cpu.cuda().to(torch.bfloat16),
+            cos_cpu.cuda().to(torch.bfloat16),
+            sin_cpu.cuda().to(torch.bfloat16),
+        )
+
+        torch.testing.assert_close(
+            Q_out_cuda.float().cpu(), Q_expected, atol=1e-2, rtol=1e-2,
+        )
+        torch.testing.assert_close(
+            K_out_cuda.float().cpu(), K_expected, atol=1e-2, rtol=1e-2,
         )

--- a/unturtle/models/a2d/_fast_forward.py
+++ b/unturtle/models/a2d/_fast_forward.py
@@ -191,9 +191,15 @@ def A2DAttention_fast_forward(
     if position_embeddings is not None:
         cos, sin = position_embeddings
         if Q.device.type == "cuda":
-            Q, K = fast_rope_embedding(Q, K, cos, sin, position_ids)
+            if position_ids is not None and cos.ndim == 3 and cos.shape[0] == bsz:
+                cos = cos.reshape(-1, cos.shape[-1])
+                sin = sin.reshape(-1, sin.shape[-1])
+                rope_indices = torch.arange(bsz * q_len, device=Q.device, dtype=torch.long)
+                Q, K = fast_rope_embedding(Q, K, cos, sin, rope_indices)
+            else:
+                Q, K = fast_rope_embedding(Q, K, cos, sin)
         else:
-            # CPU fallback: plain rotate_half RoPE
+            # CPU fallback: plain rotate_half RoPE on pre-indexed cos/sin
             Q, K = _rotate_half_rope(Q, K, cos, sin, position_ids)
     # If position_embeddings is None, skip RoPE (shouldn't happen for A2D models
     # since A2DLlamaModel.forward always computes and passes them)


### PR DESCRIPTION
## Summary

- fix A2D CUDA RoPE handling in `A2DAttention_fast_forward` so pre-indexed `(B, L, D)` rotary embeddings are not double-indexed
- preserve the broadcasted `(1, L, D)` CUDA path and add regressions for both broadcasted and flattened pre-indexed RoPE inputs
- document the RoPE gotcha in `CLAUDE.md` and `AGENTS.md`

## Test plan

- [x] `python -m pytest tests/models/test_a2d.py::TestA2DRoPE -q`
- [x] `python -m pytest tests/models/test_a2d.py::TestA2DPackedForward -q`
- [x] `python -m pytest tests/test_fast_diffusion_model.py::TestA2DAttentionFastForward -q`
- [x] `python -m pytest tests/models/test_a2d.py -q`

Closes #49