### PR TITLE
✨ feat(api): re-export unsloth optimizers from unturtle (#44)

### DIFF
--- a/unturtle/__init__.py
+++ b/unturtle/__init__.py
@@ -76,6 +76,9 @@ from unturtle.models import (  # noqa: F401
     A2DLlamaConfig,
     A2DLlamaModel,
     A2DLlamaLMHeadModel,
+    A2DModernBertConfig,
+    A2DModernBertModel,
+    A2DModernBertForMaskedLM,
     A2DQwen2Config,
     A2DQwen2Model,
     A2DQwen2LMHeadModel,
@@ -96,11 +99,20 @@ DreamForDiffusionLM = DreamModel  # noqa: F401
 # ---------------------------------------------------------------------------
 # Optimizers
 # Re-export unsloth optimizers when available so users can write
-#   from unturtle import UnslothAdamW
+#   from unturtle import QGaLoreAdamW8bit
 # instead of reaching into unsloth directly.
 # TODO(Phase Z): once unsloth dependency is removed, vendor or reimplement
 #   these optimizers inside unturtle.optimizers and update these imports.
 # ---------------------------------------------------------------------------
+try:
+    from unsloth.optimizers import (  # noqa: F401
+        GaLoreProjector,
+        QGaLoreAdamW8bit,
+    )
+except (ImportError, AttributeError):
+    pass  # Older unsloth versions that do not expose these symbols
+
+# UnslothAdamW family — available in newer unsloth releases
 try:
     from unsloth.optimizers import (  # noqa: F401
         UnslothAdamW,
@@ -108,4 +120,4 @@ try:
         UnslothAdamWScheduleFree,
     )
 except (ImportError, AttributeError):
-    pass  # Older unsloth versions that do not expose these symbols
+    pass


### PR DESCRIPTION
## Summary

- `from unturtle import QGaLoreAdamW8bit, GaLoreProjector` が動作するように
- `UnslothAdamW` 系は現バージョンの unsloth に未実装のため `try/except` で graceful skip
- `A2DModernBertConfig / A2DModernBertForMaskedLM` を `unturtle` トップレベルに追加 (PR #60 で漏れていた)

## Changes

| File | 変更内容 |
|------|---------|
| `unturtle/__init__.py` | GaLoreProjector/QGaLoreAdamW8bit re-export、UnslothAdamW系graceful skip、A2DModernBert*追加 |

## Test plan

- [x] `python -m pytest tests/diffusion/ tests/models/ tests/test_fast_diffusion_model.py tests/test_e2e_integration.py -q` — 222 passed, 1 skipped
- [x] `from unturtle import QGaLoreAdamW8bit, GaLoreProjector` — OK
- [x] `hasattr(unturtle, 'UnslothAdamW') == False` (graceful skip) — OK

## 関連

- Closes #44