### PR TITLE
✨ feat(a2d): ModernBERT bidirectional fast attention + Triton O-proj (#59)

### DIFF
--- a/tests/test_fast_diffusion_model.py
+++ b/tests/test_fast_diffusion_model.py
@@ -936,3 +936,88 @@ def _all_gc_flags_false(model):
 def _all_gc_flags_true(model):
     flags = [m.gradient_checkpointing for m in model.modules() if hasattr(m, "gradient_checkpointing")]
     return all(flag is True for flag in flags)
+
+
+# ---------------------------------------------------------------------------
+# ModernBERT PEFT patching tests
+# ---------------------------------------------------------------------------
+
+
+def _tiny_modernbert_config():
+    from unturtle.models.a2d import A2DModernBertConfig
+    return A2DModernBertConfig(
+        vocab_size=1000,
+        hidden_size=128,
+        intermediate_size=256,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        max_position_embeddings=128,
+        pad_token_id=0,
+        bos_token_id=1,
+        eos_token_id=2,
+        cls_token_id=1,
+        sep_token_id=2,
+    )
+
+
+class TestModernBertPeftPatching:
+    """CPU tests for _patch_modernbert_peft and ModernBertAttention_fast_forward."""
+
+    @pytest.fixture
+    def peft_model(self):
+        from peft import LoraConfig, TaskType, get_peft_model
+        from unturtle.models.a2d import A2DModernBertForMaskedLM
+
+        config = _tiny_modernbert_config()
+        model = A2DModernBertForMaskedLM(config)
+        lora_config = LoraConfig(
+            r=4,
+            target_modules=["Wqkv", "Wo"],
+            task_type=TaskType.FEATURE_EXTRACTION,
+            lora_dropout=0,
+            bias="none",
+        )
+        return get_peft_model(model, lora_config)
+
+    def test_patch_peft_model_does_not_raise_on_cpu(self, peft_model):
+        """patch_peft_model must succeed on CPU (Triton skipped gracefully)."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+        FastDiffusionModel.patch_peft_model(peft_model, lora_dropout=0, bias="none")
+
+    def test_fast_forward_injected_on_cuda(self, peft_model):
+        """ModernBertAttention_fast_forward must be injected on CUDA."""
+        pytest.importorskip("torch.cuda", reason="CUDA required")
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA not available")
+
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+        from unturtle.models.a2d._fast_forward import ModernBertAttention_fast_forward
+
+        cuda_model = peft_model.cuda()
+        FastDiffusionModel.patch_peft_model(cuda_model, lora_dropout=0, bias="none")
+
+        for layer in cuda_model.base_model.model.model.layers:
+            assert layer.attn.forward.__func__ is ModernBertAttention_fast_forward, (
+                "ModernBertAttention_fast_forward was not injected on CUDA"
+            )
+
+    def test_forward_logits_shape_after_patch_cpu(self, peft_model):
+        """Forward pass shape is correct after CPU patch (fast_forward not injected)."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+
+        FastDiffusionModel.patch_peft_model(peft_model, lora_dropout=0, bias="none")
+        peft_model.eval()
+        B, L = 2, 16
+        input_ids = torch.randint(3, 1000, (B, L))
+        with torch.no_grad():
+            out = peft_model(input_ids=input_ids)
+        assert out.logits.shape == (B, L, 1000)
+
+    def test_apply_wo_stub_installed(self, peft_model):
+        """apply_wo stubs must be present after patching."""
+        from unturtle.fast_diffusion_model import FastDiffusionModel
+        from unturtle.models.a2d._fast_forward import _original_apply_wo
+
+        FastDiffusionModel.patch_peft_model(peft_model, lora_dropout=0, bias="none")
+        for layer in peft_model.base_model.model.model.layers:
+            assert hasattr(layer.attn, "apply_wo"), "apply_wo stub missing after patch"

--- a/unturtle/fast_diffusion_model.py
+++ b/unturtle/fast_diffusion_model.py
@@ -66,7 +66,11 @@ from unturtle.kernels.fast_lora import apply_lora_qkv_with_bias
 from unsloth.models._utils import prepare_model_for_kbit_training
 from unsloth.save import patch_saving_functions
 
-from unturtle.models.a2d._fast_forward import A2DAttention_fast_forward
+from unturtle.models.a2d._fast_forward import (
+    A2DAttention_fast_forward,
+    ModernBertAttention_fast_forward,
+    _install_modernbert_stubs,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -92,6 +96,9 @@ _DREAM_MODEL_TYPES = frozenset(["dream", "Dream"])
 
 # LLaDA model_type
 _LLADA_MODEL_TYPES = frozenset(["llada"])
+
+# ModernBERT A2D model_type
+_MODERNBERT_A2D_MODEL_TYPES = frozenset(["a2d-modernbert"])
 
 
 # ---------------------------------------------------------------------------
@@ -397,6 +404,82 @@ def _patch_llada_peft(
             )
 
     return n_qkv, n_o, n_mlp
+
+
+def _patch_modernbert_peft(
+    model: Any, lora_dropout: float, bias: Literal["none", "all", "lora_only"]
+) -> tuple[int, int, int]:
+    """Patch A2DModernBertForMaskedLM with bidirectional fast attention and Triton O-projection.
+
+    ModernBERT uses fused ``Wqkv`` and ``Wo`` (attention) and ``Wi`` / ``Wo`` (MLP).
+    Unlike the LLaMA/Qwen2 path, QKV and MLP Triton kernels are **not** applied
+    in this initial implementation because the fused projection shapes differ from
+    what ``apply_lora_qkv`` / ``apply_lora_mlp_swiglu`` expect.
+
+    What IS patched:
+    - ``layer.attn.forward`` → ``ModernBertAttention_fast_forward`` (CUDA only)
+    - ``layer.attn.Wo``     → ``apply_lora_o`` when conditions allow (CUDA, no dropout, no bias)
+
+    Layer hierarchy:
+        PeftModel → base_model → model (A2DModernBertForMaskedLM)
+            → model (A2DModernBertModel) → layers[i].attn / .mlp
+
+    Returns (n_qkv_patched=0, n_o_patched, n_mlp_patched=0).
+    """
+    n_o = 0
+
+    first_param = next(iter(model.parameters()), None)
+    on_cuda = first_param is not None and first_param.device.type == "cuda"
+
+    # A2DModernBertForMaskedLM wraps A2DModernBertModel in self.model
+    # Path: PeftModel → base_model → model (LM) → model (encoder) → layers
+    try:
+        layers = model.base_model.model.model.layers
+    except AttributeError:
+        _warn_once(
+            "FastDiffusionModel (ModernBERT): could not locate model.layers — "
+            "is this a valid A2DModernBertForMaskedLM PEFT model?"
+        )
+        return 0, 0, 0
+
+    # Install apply_wo stubs unconditionally (CPU + CUDA) so fast_forward
+    # and downstream code can dispatch through apply_wo regardless of device.
+    _install_modernbert_stubs(model)
+
+    if not on_cuda:
+        return 0, 0, 0
+
+    for layer in layers:
+        attn = getattr(layer, "attn", None)
+        if attn is None:
+            continue
+
+        # Always inject bidirectional fast-forward on CUDA
+        attn.forward = types.MethodType(ModernBertAttention_fast_forward, attn)
+
+        if lora_dropout != 0 or bias != "none":
+            continue
+
+        # Wo output projection — apply Triton apply_lora_o when conditions met
+        wo = getattr(attn, "Wo", None)
+        if (
+            wo is not None
+            and hasattr(wo, "lora_A")
+            and _no_bias(wo)
+            and _no_lora_mag(wo)
+        ):
+            # Redirect apply_wo to Triton apply_lora_o.
+            # apply_lora_o reads self.o_proj — we alias Wo as o_proj for compatibility.
+            attn.o_proj = attn.Wo
+            attn.apply_wo = apply_lora_o
+            n_o += 1
+        elif wo is not None and not hasattr(wo, "lora_A"):
+            _warn_once(
+                "FastDiffusionModel (ModernBERT): Wo has no LoRA adapter — "
+                "is 'Wo' in target_modules?"
+            )
+
+    return 0, n_o, 0
 
 
 def _no_bias(proj: Any) -> bool:
@@ -758,11 +841,23 @@ class FastDiffusionModel:
                 f"FastDiffusionModel (LLaDA) patched {n_blocks} blocks with "
                 f"{n_qkv} QKV blocks and {n_o} O (attn_out) blocks."
             )
+        elif model_type in _MODERNBERT_A2D_MODEL_TYPES:
+            _n_qkv, n_o, _n_mlp = _patch_modernbert_peft(model, lora_dropout, bias)
+            n_layers = len(model.base_model.model.model.layers)
+            _warn_once(
+                f"FastDiffusionModel (ModernBERT) patched {n_layers} layers with "
+                f"{n_o} Wo (output proj) layers. "
+                "Wqkv/MLP Triton kernels not yet supported for ModernBERT — "
+                "see issue #59 Phase 2."
+            )
         else:
             raise NotImplementedError(
                 f"FastDiffusionModel does not yet support model_type={model_type!r}. "
                 "Supported types: "
-                + ", ".join(sorted(_A2D_MODEL_TYPES | _DREAM_MODEL_TYPES | _LLADA_MODEL_TYPES))
+                + ", ".join(sorted(
+                    _A2D_MODEL_TYPES | _DREAM_MODEL_TYPES
+                    | _LLADA_MODEL_TYPES | _MODERNBERT_A2D_MODEL_TYPES
+                ))
             )
 
         # Propagate max_seq_length through the wrapped model hierarchy

--- a/unturtle/models/a2d/_fast_forward.py
+++ b/unturtle/models/a2d/_fast_forward.py
@@ -277,3 +277,105 @@ def A2DAttention_fast_forward(
     # Dispatch through apply_o — uses Triton fused kernel when patched
     attn_output = self.apply_o(self, attn_output)
     return attn_output, None
+
+
+# ---------------------------------------------------------------------------
+# ModernBERT bidirectional fast attention forward
+# ---------------------------------------------------------------------------
+
+
+def ModernBertAttention_fast_forward(
+    self,
+    hidden_states: torch.Tensor,
+    position_embeddings: Optional[tuple] = None,
+    attention_mask: Optional[torch.Tensor] = None,
+    **kwargs,
+) -> tuple:
+    """Drop-in replacement for ``ModernBertAttention.forward``.
+
+    Dispatches through ``self.apply_wo`` (set by ``_patch_modernbert_peft``) so
+    that the Triton-fused ``apply_lora_o`` kernel is used for the output
+    projection when LoRA is present.
+
+    Key differences from upstream ``ModernBertAttention.forward``:
+    - ``is_causal=False`` is enforced (upstream already does this via
+      ``self.is_causal = False``, but we make it explicit for SDPA fallback).
+    - Output projection dispatches through ``self.apply_wo`` stub, enabling
+      Triton LoRA patching of ``attn.Wo``.
+
+    Note: Wqkv and RoPE are handled identically to the upstream — no double
+    indexing occurs because ``position_embeddings`` is already pre-indexed
+    ``(cos, sin)`` from ``ModernBertModel.forward``.
+    """
+    input_shape = hidden_states.shape[:-1]
+    bsz, q_len, _ = hidden_states.shape
+
+    n_heads = self.config.num_attention_heads
+    head_dim = self.head_dim
+
+    # Fused QKV projection + reshape: [B, L, 3*H*D] → [B, L, 3, H, D] → unbind
+    qkv = self.Wqkv(hidden_states)
+    qkv = qkv.view(*input_shape, 3, n_heads, head_dim)
+    Q, K, V = qkv.unbind(dim=-3)
+
+    # Q/K/V: [B, L, H, D] → [B, H, L, D]
+    Q = Q.transpose(1, 2)
+    K = K.transpose(1, 2)
+    V = V.transpose(1, 2)
+
+    # RoPE: position_embeddings is pre-indexed (cos, sin) from ModernBertModel.forward.
+    # Apply directly — no re-indexing needed (no A2D RoPE double-index bug here).
+    if position_embeddings is not None:
+        cos, sin = position_embeddings
+        # cos/sin shape: [B, L, D] — unsqueeze head dim for broadcasting
+        cos = cos.unsqueeze(1)
+        sin = sin.unsqueeze(1)
+        Q = (Q.float() * cos + _rotate_half(Q.float()) * sin).to(Q.dtype)
+        K = (K.float() * cos + _rotate_half(K.float()) * sin).to(K.dtype)
+
+    # Bidirectional attention via SDPA (is_causal=False enforced)
+    scale = head_dim ** -0.5
+    if HAS_FLASH_ATTENTION and hidden_states.device.type == "cuda":
+        from flash_attn import flash_attn_func
+        # flash_attn expects [B, L, H, D]
+        Q_fa = Q.transpose(1, 2)
+        K_fa = K.transpose(1, 2)
+        V_fa = V.transpose(1, 2)
+        attn_out = flash_attn_func(Q_fa, K_fa, V_fa, causal=False)
+        attn_output = attn_out.reshape(bsz, q_len, n_heads * head_dim)
+    else:
+        attn_out = torch.nn.functional.scaled_dot_product_attention(
+            Q, K, V,
+            attn_mask=attention_mask,
+            dropout_p=self.attention_dropout if self.training else 0.0,
+            is_causal=False,
+            scale=scale,
+        )
+        attn_output = attn_out.transpose(1, 2).reshape(bsz, q_len, n_heads * head_dim)
+
+    attn_output = self.out_drop(self.apply_wo(self, attn_output))
+    return attn_output, None
+
+
+def _rotate_half(x: torch.Tensor) -> torch.Tensor:
+    """Rotate the second half of the last dimension."""
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def _original_apply_wo(self, X: torch.Tensor) -> torch.Tensor:
+    """Default stub: pass through self.Wo (the output projection)."""
+    return self.Wo(X)
+
+
+def _install_modernbert_stubs(model) -> None:
+    """Set apply_wo stub on all ModernBertAttention layers that lack it.
+
+    Required before _patch_modernbert_peft or before using
+    ModernBertAttention_fast_forward without PEFT.
+    """
+    for module in model.modules():
+        if hasattr(module, "Wqkv") and hasattr(module, "Wo"):
+            if not hasattr(module, "apply_wo"):
+                module.apply_wo = _original_apply_wo

--- a/unturtle/models/a2d/_fast_forward.py
+++ b/unturtle/models/a2d/_fast_forward.py
@@ -293,75 +293,60 @@ def ModernBertAttention_fast_forward(
 ) -> tuple:
     """Drop-in replacement for ``ModernBertAttention.forward``.
 
-    Dispatches through ``self.apply_wo`` (set by ``_patch_modernbert_peft``) so
-    that the Triton-fused ``apply_lora_o`` kernel is used for the output
-    projection when LoRA is present.
+    Delegates entirely to the upstream implementation for QKV projection, RoPE,
+    Flash/SDPA attention (including sliding_window, dropout, deterministic),
+    and ``out_drop`` — then replaces only the final ``self.Wo(attn_output)``
+    call with ``self.apply_wo(self, attn_output)`` so that the Triton-fused
+    ``apply_lora_o`` kernel is used when patched in by
+    ``_patch_modernbert_peft``.
 
-    Key differences from upstream ``ModernBertAttention.forward``:
-    - ``is_causal=False`` is enforced (upstream already does this via
-      ``self.is_causal = False``, but we make it explicit for SDPA fallback).
-    - Output projection dispatches through ``self.apply_wo`` stub, enabling
-      Triton LoRA patching of ``attn.Wo``.
-
-    Note: Wqkv and RoPE are handled identically to the upstream — no double
-    indexing occurs because ``position_embeddings`` is already pre-indexed
-    ``(cos, sin)`` from ``ModernBertModel.forward``.
+    Upstream ``ModernBertAttention`` already sets ``self.is_causal = False``, so
+    bidirectionality is preserved without any attention path changes.
     """
+    from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+    from transformers.models.modernbert.modeling_modernbert import (
+        apply_rotary_pos_emb,
+        eager_attention_forward,
+    )
+
     input_shape = hidden_states.shape[:-1]
-    bsz, q_len, _ = hidden_states.shape
 
-    n_heads = self.config.num_attention_heads
-    head_dim = self.head_dim
-
-    # Fused QKV projection + reshape: [B, L, 3*H*D] → [B, L, 3, H, D] → unbind
     qkv = self.Wqkv(hidden_states)
-    qkv = qkv.view(*input_shape, 3, n_heads, head_dim)
-    Q, K, V = qkv.unbind(dim=-3)
+    qkv = qkv.view(*input_shape, 3, -1, self.head_dim)
+    query_states, key_states, value_states = qkv.unbind(dim=-3)
 
-    # Q/K/V: [B, L, H, D] → [B, H, L, D]
-    Q = Q.transpose(1, 2)
-    K = K.transpose(1, 2)
-    V = V.transpose(1, 2)
+    query_states = query_states.transpose(1, 2)
+    key_states = key_states.transpose(1, 2)
+    value_states = value_states.transpose(1, 2)
 
-    # RoPE: position_embeddings is pre-indexed (cos, sin) from ModernBertModel.forward.
-    # Apply directly — no re-indexing needed (no A2D RoPE double-index bug here).
     if position_embeddings is not None:
         cos, sin = position_embeddings
-        # cos/sin shape: [B, L, D] — unsqueeze head dim for broadcasting
-        cos = cos.unsqueeze(1)
-        sin = sin.unsqueeze(1)
-        Q = (Q.float() * cos + _rotate_half(Q.float()) * sin).to(Q.dtype)
-        K = (K.float() * cos + _rotate_half(K.float()) * sin).to(K.dtype)
-
-    # Bidirectional attention via SDPA (is_causal=False enforced)
-    scale = head_dim ** -0.5
-    if HAS_FLASH_ATTENTION and hidden_states.device.type == "cuda":
-        from flash_attn import flash_attn_func
-        # flash_attn expects [B, L, H, D]
-        Q_fa = Q.transpose(1, 2)
-        K_fa = K.transpose(1, 2)
-        V_fa = V.transpose(1, 2)
-        attn_out = flash_attn_func(Q_fa, K_fa, V_fa, causal=False)
-        attn_output = attn_out.reshape(bsz, q_len, n_heads * head_dim)
-    else:
-        attn_out = torch.nn.functional.scaled_dot_product_attention(
-            Q, K, V,
-            attn_mask=attention_mask,
-            dropout_p=self.attention_dropout if self.training else 0.0,
-            is_causal=False,
-            scale=scale,
+        query_states, key_states = apply_rotary_pos_emb(
+            query_states, key_states, cos, sin, unsqueeze_dim=1
         )
-        attn_output = attn_out.transpose(1, 2).reshape(bsz, q_len, n_heads * head_dim)
 
+    attention_interface = eager_attention_forward
+    if self.config._attn_implementation != "eager":
+        attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
+
+    attn_output, attn_weights = attention_interface(
+        self,
+        query_states,
+        key_states,
+        value_states,
+        attention_mask,
+        dropout=self.attention_dropout if self.training else 0.0,
+        scaling=self.head_dim ** -0.5,
+        sliding_window=self.sliding_window,
+        deterministic=self.deterministic_flash_attn,
+        **kwargs,
+    )
+
+    attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+    # Dispatch through apply_wo instead of self.Wo directly —
+    # enables Triton apply_lora_o when patched by _patch_modernbert_peft.
     attn_output = self.out_drop(self.apply_wo(self, attn_output))
-    return attn_output, None
-
-
-def _rotate_half(x: torch.Tensor) -> torch.Tensor:
-    """Rotate the second half of the last dimension."""
-    x1 = x[..., : x.shape[-1] // 2]
-    x2 = x[..., x.shape[-1] // 2 :]
-    return torch.cat((-x2, x1), dim=-1)
+    return attn_output, attn_weights
 
 
 def _original_apply_wo(self, X: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
## Summary

A2DModernBertForMaskedLM を `FastDiffusionModel.get_peft_model` でサポート。

**実装内容**:
- `ModernBertAttention_fast_forward`: Flash Attention (causal=False) / SDPA (is_causal=False) + `apply_wo` stub dispatch
- `_patch_modernbert_peft`: CUDA 上で fast-forward inject + `attn.Wo` への `apply_lora_o` 適用
- `_install_modernbert_stubs`: `apply_wo` スタブの事前インストール (CPU でも実行)
- `patch_peft_model` dispatch: `"a2d-modernbert"` を `_MODERNBERT_A2D_MODEL_TYPES` に追加

**Phase 2 (未対応)**:
- `Wqkv` fused LoRA — `apply_lora_qkv` は split QKV 前提のため非互換
- MLP `Wi`/`Wo` Triton — `apply_lora_mlp_swiglu` は `gate/up/down` 前提のため非互換

## Changes

| File | 変更内容 |
|------|---------|
| `unturtle/models/a2d/_fast_forward.py` | `ModernBertAttention_fast_forward`, stubs 追加 |
| `unturtle/fast_diffusion_model.py` | `_patch_modernbert_peft`, dispatch 追加 |
| `tests/test_fast_diffusion_model.py` | `TestModernBertPeftPatching` (4 CPU tests) 追加 |

## Test plan

- [x] `python -m pytest tests/ -q` — 226 passed, 1 skipped
- [x] `TestModernBertPeftPatching` — 4 tests (CPU): patch無エラー、forward shape、apply_wo stub確認
- [ ] GPU: fast-forward inject / apply_lora_o on Wo — requires CUDA

## 関連

- Closes #59 (Phase 1)
- Phase 2 (Wqkv/MLP Triton) は別 issue として継続