### PR TITLE
⚡ perf(dream): Triton RoPE fast path for DreamAttention (#64)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,6 +217,8 @@ These rules apply to `_patch_a2d_peft`, `_patch_dream_peft`, `_patch_llada_peft`
 | `load_in_4bit` without `device_map` OOM on crowded GPU | OOM caught silently → falls through to Hub class → `all_tied_weights_keys` error | `FastDiffusionModel.from_pretrained` sets `device_map="auto"` automatically when `load_in_4bit=True` |
 | A2D CUDA RoPE with pre-indexed `position_embeddings` | Packed/non-monotonic `position_ids` produce wrong CUDA outputs despite CPU fallback passing | `self.rotary_emb(hidden_states, position_ids)` already returns cos/sin aligned to `position_ids`; in `A2DAttention_fast_forward` flatten `(B,L,D)` cos/sin to `(B*L,D)` and pass flat row indices `arange(B*L)` instead of reusing `position_ids` |
 | Attempting to fully decouple from unsloth | High effort with low dLLM value — vendoring trainer/kernels/optimizers gets very complex | **unturtle is a dLLM-specialized library that depends on unsloth** — don't try to remove unsloth dependency; focus effort on dLLM-specific components (bidirectional attention, masked diffusion loss, generation utils) |
+| `fast_rope_embedding` expects `(rows, head_dim//2)` cos/sin, but Dream/LlaMA RotaryEmbedding returns `(B, L, head_dim)` with cat(freqs,freqs) pattern | CUDA/CPU parity test fails with large diff (~10x) even though shapes seem OK | Slice `cos[..., :head_dim//2]` before `reshape(-1, head_dim//2)` when passing Dream cos/sin to `fast_rope_embedding`; A2D works automatically because `LlamaRotaryEmbedding` already returns `(B, L, head_dim//2)` |
+| `fast_rope_embedding` is in-place | CPU/CUDA parity tests fail when the same tensor is passed to both paths sequentially | Always `.clone()` Q/K before passing to `fast_rope_embedding` in tests that compare CPU and CUDA outputs |
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,6 +216,7 @@ These rules apply to `_patch_a2d_peft`, `_patch_dream_peft`, `_patch_llada_peft`
 | `LLaDAModelLM` lacks `all_tied_weights_keys` (Hub class) | `AttributeError: 'LLaDAModelLM' has no attribute 'all_tied_weights_keys'` during 4-bit load | `FastDiffusionModel._load_model_auto` routes `model_type="llada"` to unturtle's own class; unturtle class calls `self.post_init()` and accepts `tie_weights(**kwargs)` |
 | `load_in_4bit` without `device_map` OOM on crowded GPU | OOM caught silently → falls through to Hub class → `all_tied_weights_keys` error | `FastDiffusionModel.from_pretrained` sets `device_map="auto"` automatically when `load_in_4bit=True` |
 | A2D CUDA RoPE with pre-indexed `position_embeddings` | Packed/non-monotonic `position_ids` produce wrong CUDA outputs despite CPU fallback passing | `self.rotary_emb(hidden_states, position_ids)` already returns cos/sin aligned to `position_ids`; in `A2DAttention_fast_forward` flatten `(B,L,D)` cos/sin to `(B*L,D)` and pass flat row indices `arange(B*L)` instead of reusing `position_ids` |
+| Attempting to fully decouple from unsloth | High effort with low dLLM value — vendoring trainer/kernels/optimizers gets very complex | **unturtle is a dLLM-specialized library that depends on unsloth** — don't try to remove unsloth dependency; focus effort on dLLM-specific components (bidirectional attention, masked diffusion loss, generation utils) |
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,24 +101,24 @@ from unturtle import FastDiffusionModel           # Phase C 追加
 - `A2DAttention_fast_forward` (bidirectional, causal=False) を injection
 - `TaskType.FEATURE_EXTRACTION` で PEFT ラップ (CAUSAL_LM guard 回避)
 
-### 将来目標: Phase Z — unsloth 完全移行
+### unsloth との依存関係方針 (2026-04 確定)
 
-**最終的なあるべき姿**: unturtle が unsloth に依存しない独立した dLLM フレームワークになること。
-現在 `unturtle/__init__.py` の `from unsloth import *` に依存している以下のコンポーネントを
-順次 unturtle 内で再実装・ベンダリングする:
+**unturtle は unsloth に依存する dLLM 特化ライブラリ** として開発する。
+unsloth からの完全独立化 (旧 Phase Z) は **プロジェクトの目標ではない**。
 
-| コンポーネント | 現状 | Phase Z での対応 |
-|--------------|------|----------------|
-| `Fast_CrossEntropyLoss` (Triton CE) | `unsloth/kernels/cross_entropy_loss.py` | `unturtle/kernels/` に移植 |
-| `fast_rope_embedding` | `unsloth/kernels/rope_embedding.py` | `unturtle/kernels/` に移植 |
-| `apply_lora_qkv` / `apply_lora_o` | `unsloth/kernels/fast_lora.py` | `unturtle/kernels/fast_lora.py` に統合 |
-| `run_attention` / `select_attention_backend` | `unsloth/utils/attention_dispatch.py` | `unturtle/utils/` に移植 |
-| `get_packed_info_from_kwargs` | `unsloth/utils/packing.py` | `unturtle/utils/` に移植 |
-| `UnslothTrainer` / `UnslothTrainingArguments` | `unsloth/trainer.py` | `DiffusionTrainer` が直接 `SFTTrainer` を継承 |
-| `FastLanguageModel` (AR 用) | `unsloth/models/` | 不要 (dLLM では `FastDiffusionModel` のみ) |
-| Optimizers | `unsloth/optimizers.py` (未実装) | `unturtle/optimizers.py` に実装 |
+**方針**:
+- unsloth のカーネル最適化 (`fast_rope_embedding`, `Fast_CrossEntropyLoss`, LoRA kernels) はそのまま利用する
+- `DiffusionTrainer` は `UnslothTrainer` を継承し続けて問題ない
+- unturtle が提供する価値は **dLLM 特有のコンポーネント** に集中する:
+  - bidirectional attention fast forward (A2D / Dream / LLaDA)
+  - masked diffusion loss kernel
+  - dLLM 生成ユーティリティ (MDLM denoising loop, KV cache)
+  - dLLM 学習・評価ハーネス
 
-進捗はこのセクションと各ファイルの `# TODO(Phase Z):` コメントで追跡する。
+**`unturtle/utils/` について** (Phase Z 作業の残滓):
+- `packing.py`, `attention_dispatch.py`, `_runtime.py` は A2D fast forward パスが直接利用するため有効
+- `unturtle/trainer.py` のベンダリングは将来 revert 候補 (現状は動作するため放置)
+- `# TODO(Phase Z):` コメントは将来対応不要なため気にしなくてよい
 
 ---
 
@@ -144,7 +144,7 @@ from unturtle import FastDiffusionModel           # Phase C 追加
 | Phase H | `tests/models/`, `unturtle/models/a2d/modeling_modernbert.py` | RoPE テスト + ModernBERT A2D | ✅ 完了 |
 | Phase H+ | `unturtle/models/dream/`, `unturtle/models/llada/`, `unsloth/kernels/rope_embedding.py` | Dream/LLaDA の Triton RoPE 最適化適用可能性を評価 | 🔍 調査完了 (#58, 詳細は下記) |
 | Phase I | `dev/distributed.md` | 分散学習 (FSDP / DeepSpeed ZeRO) の制約ドキュメント化・推奨設定 | ✅ 完了 (#51) |
-| Phase Z | `unturtle/` 全体 | unsloth 完全移行・依存除去 | 🔲 長期目標 |
+| ~~Phase Z~~ | ~~`unturtle/` 全体~~ | ~~unsloth 完全移行・依存除去~~ | ❌ 方針転換により廃止 (#67-#69 クローズ) |
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,7 @@ from unturtle import FastDiffusionModel           # Phase C 追加
 | Phase F | `unturtle/models/diffusion_generation_utils.py`, `unturtle/models/a2d/generation_utils.py`, `unturtle/models/llada/generation_utils.py` | A2D / LLaDA 生成ユーティリティ (MDLM デノイジングループ) | ✅ 完了 |
 | Phase G | `unturtle/eval/` | 評価ハーネス | ✅ 完了 |
 | Phase H | `tests/models/`, `unturtle/models/a2d/modeling_modernbert.py` | RoPE テスト + ModernBERT A2D | ✅ 完了 |
-| Phase H+ | `unturtle/models/dream/`, `unturtle/models/llada/`, `unsloth/kernels/rope_embedding.py` | Dream/LLaDA の Triton RoPE 最適化適用可能性を評価 | 📝 backlog (#58) |
+| Phase H+ | `unturtle/models/dream/`, `unturtle/models/llada/`, `unsloth/kernels/rope_embedding.py` | Dream/LLaDA の Triton RoPE 最適化適用可能性を評価 | 🔍 調査完了 (#58, 詳細は下記) |
 | Phase I | `dev/distributed.md` | 分散学習 (FSDP / DeepSpeed ZeRO) の制約ドキュメント化・推奨設定 | ✅ 完了 (#51) |
 | Phase Z | `unturtle/` 全体 | unsloth 完全移行・依存除去 | 🔲 長期目標 |
 
@@ -871,3 +871,62 @@ args = DiffusionTrainingArguments(
 - LLaDA FSDP 対応調査 (buffer 問題の根本原因)
 - DeepSpeed ZeRO-2 と Triton カーネルの stream 競合調査
 - `tests/test_distributed.py` 新設
+
+---
+
+## Phase H+ 調査結果 — Dream / LLaDA Triton RoPE & ModernBERT 最適化 (#58)
+
+### Dream の Triton RoPE 適用可能性 (MEDIUM リスク)
+
+**現状**: `DreamAttention.forward` と `DreamSdpaAttention.forward` (lines 329, 420) はいずれも
+`apply_rotary_pos_emb(query_states, key_states, cos, sin)` を使用している。
+`cos/sin` は `DreamRotaryEmbedding.forward(hidden_states, position_ids)` が事前に
+`position_ids` に沿って生成した shape `(B, L, head_dim)` のテンソル。
+
+**最適化方針** (未実装):
+- CUDA 時に `fast_rope_embedding` を呼ぶには、A2D の gotcha #16 と同じ flatten+arange パターンが必要
+- `cos/sin` はすでに `position_ids` でインデックス済みのため、そのまま `fast_rope_embedding` に
+  渡すと二重インデックスになる (A2D の修正前と同じバグ)
+- 正しい実装:
+  ```python
+  # Dream attention forward (CUDA path):
+  cos, sin = position_embeddings  # (B, L, head_dim) — pre-indexed
+  cos_flat = cos.reshape(-1, cos.shape[-1])   # (B*L, head_dim)
+  sin_flat = sin.reshape(-1, sin.shape[-1])   # (B*L, head_dim)
+  rope_indices = torch.arange(bsz * q_len, device=Q.device, dtype=torch.long)
+  Q, K = fast_rope_embedding(Q, K, cos_flat, sin_flat, rope_indices)
+  ```
+- Dream は `_patch_dream_peft` で attention の `apply_qkv` / `apply_o` をすでに置換している。
+  RoPE 最適化は `DreamAttention_fast_forward` を追加する形で実装する
+
+**ブロッカー**: `fast_rope_embedding` の呼び出し先が `unsloth.kernels.rope_embedding` であり、
+Phase Z 前は unsloth 依存が残る。今は後回しにして Phase H+ 実装 issue で対応予定。
+
+### LLaDA の Triton RoPE 適用可能性 (LOW リスク)
+
+**現状**: `LLaDABlock._scaled_dot_product_attention` の line 715 にて
+`q, k = self.rotary_emb(q, k)` を呼んでいる。`RotaryEmbedding.forward(q, k)` は
+シーケンス順ベースで pos テーブルを内部生成する独自インターフェース (position_ids なし)。
+
+**最適化方針** (未実装):
+- `RotaryEmbedding.forward` 内部の `apply_rotary_pos_emb` を CUDA 時に置換する方針
+- `pos_sin/pos_cos` は shape `(1, n_heads, seq_len, head_dim)` なので `reshape(-1, head_dim)` して
+  arange indices を渡すことで `fast_rope_embedding` が使える
+- ただしシーケンス順ベースなので double-index リスクは低く、緊急性は低い
+
+### ModernBERT Triton 最適化の現状ギャップ (#59 Phase 2)
+
+| 最適化 | 状態 | 備考 |
+|-------|------|------|
+| Triton QKV LoRA | ❌ 未適用 | `apply_lora_qkv` は split q/k/v 前提。`Wqkv` (fused) に対応した新カーネルが必要 |
+| Triton O-proj LoRA | ✅ 適用済み | `attn.o_proj = attn.Wo` エイリアス + `apply_lora_o` (#63) |
+| Triton MLP LoRA | ❌ 未適用 | `apply_lora_mlp_swiglu` は gate/up/down split 前提。`Wi` (fused GLU) + `Wo` 構造に非互換 |
+| Flash Attention 双方向 | ✅ 適用済み | upstream の `is_causal=False` をそのまま利用 (#63) |
+| 勾配チェックポイント | ✅ 適用済み | HF 汎用 `GradientCheckpointingLayer` パス |
+| 4-bit 量子化 | ✅ 適用済み | `TaskType.FEATURE_EXTRACTION` で PEFT ラップ後も動作 |
+
+**未適用の最適化を実装するために必要な新カーネル**:
+1. `apply_lora_fused_qkv` — `Wqkv` (fused 3D projection) 用 Triton LoRA カーネル
+2. `apply_lora_fused_mlp_glu` — `Wi` (GLU input) / `Wo` 用 Triton LoRA カーネル
+
+これらは Phase Z (unsloth 完全移行) のカーネル移植フェーズと合わせて検討する。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,7 @@ unsloth からの完全独立化 (旧 Phase Z) は **プロジェクトの目標
 | Phase H+ | `unturtle/models/dream/`, `unturtle/models/llada/`, `unsloth/kernels/rope_embedding.py` | Dream/LLaDA の Triton RoPE 最適化適用可能性を評価 | 🔍 調査完了 (#58, 詳細は下記) |
 | Phase I | `dev/distributed.md` | 分散学習 (FSDP / DeepSpeed ZeRO) の制約ドキュメント化・推奨設定 | ✅ 完了 (#51) |
 | ~~Phase Z~~ | ~~`unturtle/` 全体~~ | ~~unsloth 完全移行・依存除去~~ | ❌ 方針転換により廃止 (#67-#69 クローズ) |
+| Phase Z-proper | `pyproject.toml`, `unsloth/` 削除 | unsloth を外部依存化・`unsloth/` ディレクトリ削除・`from unsloth import *` を明示 re-export に置換 | 🔲 未着手 (#74) |
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -898,7 +898,12 @@ args = DiffusionTrainingArguments(
   Q, K = fast_rope_embedding(Q, K, cos_flat, sin_flat, rope_indices)
   ```
 - Dream は `_patch_dream_peft` で attention の `apply_qkv` / `apply_o` をすでに置換している。
-  RoPE 最適化は `DreamAttention_fast_forward` を追加する形で実装する
+  RoPE 最適化は `DreamAttention_fast_forward` を追加する形で実装する ✅ #64 で完了
+
+**実装時の重要な注意点** (Gotcha #17 に追記):
+- `DreamRotaryEmbedding` は `cat(freqs, freqs)` パターンで `(B, L, head_dim)` の cos/sin を返す (A2D の `LlamaRotaryEmbedding` は `(B, L, head_dim//2)` を返す)
+- `fast_rope_embedding` は cos/sin の前半 `head_dim//2` 要素のみ使うため、Dream では `cos[..., :head_dim//2]` に切り詰めてから `reshape(-1, head_dim//2)` して渡す必要がある
+- `fast_rope_embedding` は **in-place** でテンソルを書き換えるため、テストで CPU/CUDA を両方呼ぶ場合は `.clone()` が必要
 
 **ブロッカー**: `fast_rope_embedding` の呼び出し先が `unsloth.kernels.rope_embedding` であり、
 Phase Z 前は unsloth 依存が残る。今は後回しにして Phase H+ 実装 issue で対応予定。

--- a/tests/models/test_a2d.py
+++ b/tests/models/test_a2d.py
@@ -661,9 +661,9 @@ class TestA2DRoPE:
         from unturtle.models.a2d._fast_forward import _rotate_half_rope
 
         try:
-            from unsloth.kernels.rope_embedding import fast_rope_embedding
+            from unturtle.kernels.rope_embedding import fast_rope_embedding
         except ImportError:
-            pytest.skip("unsloth.kernels.rope_embedding not available")
+            pytest.skip("unturtle.kernels.rope_embedding not available")
 
         B, n_heads, L, head_dim = 1, 4, 8, 32
         torch.manual_seed(2)
@@ -696,9 +696,9 @@ class TestA2DRoPE:
         from unturtle.models.a2d._fast_forward import _rotate_half_rope
 
         try:
-            from unsloth.kernels.rope_embedding import fast_rope_embedding
+            from unturtle.kernels.rope_embedding import fast_rope_embedding
         except ImportError:
-            pytest.skip("unsloth.kernels.rope_embedding not available")
+            pytest.skip("unturtle.kernels.rope_embedding not available")
 
         B, n_heads, L, head_dim = 1, 4, 8, 32
         torch.manual_seed(3)
@@ -735,9 +735,9 @@ class TestA2DRoPE:
         from unturtle.models.a2d._fast_forward import _rotate_half_rope
 
         try:
-            from unsloth.kernels.rope_embedding import fast_rope_embedding
+            from unturtle.kernels.rope_embedding import fast_rope_embedding
         except ImportError:
-            pytest.skip("unsloth.kernels.rope_embedding not available")
+            pytest.skip("unturtle.kernels.rope_embedding not available")
 
         B, n_heads, L, head_dim = 2, 4, 8, 32
         torch.manual_seed(4)
@@ -775,9 +775,9 @@ class TestA2DRoPE:
         from unturtle.models.a2d._fast_forward import _rotate_half_rope
 
         try:
-            from unsloth.kernels.rope_embedding import fast_rope_embedding
+            from unturtle.kernels.rope_embedding import fast_rope_embedding
         except ImportError:
-            pytest.skip("unsloth.kernels.rope_embedding not available")
+            pytest.skip("unturtle.kernels.rope_embedding not available")
 
         B, n_heads, L, head_dim = 2, 4, 8, 32
         torch.manual_seed(5)

--- a/tests/models/test_a2d.py
+++ b/tests/models/test_a2d.py
@@ -267,7 +267,7 @@ class TestA2DPackedForward:
 
     def test_get_packed_info_returns_non_none_when_key_present(self, tiny_config):
         """get_packed_info_from_kwargs must return non-None when packed_seq_lengths is in kwargs."""
-        from unsloth.utils.packing import get_packed_info_from_kwargs
+        from unturtle.utils.packing import get_packed_info_from_kwargs
 
         packed_seq_lengths = torch.tensor([8, 8], dtype=torch.int32)
         kwargs = {"packed_seq_lengths": packed_seq_lengths}

--- a/tests/models/test_dream.py
+++ b/tests/models/test_dream.py
@@ -270,3 +270,166 @@ class TestDreamFastRoPE:
         assert torch.allclose(q_cpu, q_out.cpu(), atol=1e-4), (
             f"CUDA/CPU parity failed: max_diff={(q_cpu - q_out.cpu()).abs().max().item():.2e}"
         )
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Triton RoPE requires CUDA")
+    def test_cuda_parity_with_actual_reset_position_ids(self, config):
+        """CUDA fast path matches CPU for pre-indexed cos/sin derived from reset position_ids.
+
+        This is the exact failure mode from CLAUDE.md gotcha #16/#17:
+        position_ids are non-monotonic (packed/reset), cos/sin are pre-indexed
+        from those ids, and we must not double-index inside fast_rope_embedding.
+        """
+        from unturtle.models.dream import DreamConfig
+        from unturtle.models.dream.modeling_dream import _apply_dream_rope, DreamRotaryEmbedding
+
+        torch.manual_seed(3)
+        B, n_heads, L, head_dim = 2, 4, 8, 32
+        n_kv_heads = 4
+
+        # Build reset position_ids: batch 0 = [0,1,2,3,0,1,2,3], batch 1 = [0,1,2,3,4,5,6,7]
+        position_ids = torch.stack([
+            torch.tensor([0, 1, 2, 3, 0, 1, 2, 3]),
+            torch.arange(L),
+        ])
+
+        # Derive cos/sin via DreamRotaryEmbedding (same as model would do)
+        cfg = DreamConfig(
+            vocab_size=1000, hidden_size=head_dim * n_heads,
+            intermediate_size=256, num_hidden_layers=1,
+            num_attention_heads=n_heads, num_key_value_heads=n_kv_heads,
+            max_position_embeddings=128, pad_token_id=0, mask_token_id=1,
+        )
+        rotary = DreamRotaryEmbedding(config=cfg)
+        dummy_x = torch.randn(B, L, cfg.hidden_size)
+        cos, sin = rotary(dummy_x, position_ids)  # pre-indexed (B, L, head_dim)
+
+        q = torch.randn(B, n_heads, L, head_dim)
+        k = torch.randn(B, n_kv_heads, L, head_dim)
+
+        # CPU reference
+        q_cpu, k_cpu = _apply_dream_rope(q.clone(), k.clone(), cos, sin, B, L)
+
+        # CUDA fast path
+        q_cuda, k_cuda = _apply_dream_rope(
+            q.cuda().clone(), k.cuda().clone(), cos.cuda(), sin.cuda(), B, L
+        )
+
+        assert torch.allclose(q_cpu, q_cuda.cpu(), atol=1e-4), (
+            f"Q mismatch (reset pos_ids): max_diff={(q_cpu - q_cuda.cpu()).abs().max().item():.2e}"
+        )
+        assert torch.allclose(k_cpu, k_cuda.cpu(), atol=1e-4), (
+            f"K mismatch (reset pos_ids): max_diff={(k_cpu - k_cuda.cpu()).abs().max().item():.2e}"
+        )
+
+    def test_gqa_parity(self, config):
+        """_apply_dream_rope works correctly with GQA (n_kv_heads < n_heads)."""
+        from unturtle.models.dream import DreamConfig
+        from unturtle.models.dream.modeling_dream import _apply_dream_rope
+
+        torch.manual_seed(5)
+        B, n_heads, n_kv_heads, L, head_dim = 2, 8, 2, 16, 32
+
+        freqs = torch.randn(B, L, head_dim // 2)
+        cos = torch.cat([freqs.cos(), freqs.cos()], dim=-1)
+        sin = torch.cat([freqs.sin(), freqs.sin()], dim=-1)
+
+        q = torch.randn(B, n_heads, L, head_dim)
+        k = torch.randn(B, n_kv_heads, L, head_dim)
+
+        q_out, k_out = _apply_dream_rope(q.clone(), k.clone(), cos, sin, B, L)
+
+        assert q_out.shape == (B, n_heads, L, head_dim)
+        assert k_out.shape == (B, n_kv_heads, L, head_dim)
+        assert not torch.isnan(q_out).any()
+        assert not torch.isnan(k_out).any()
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Triton RoPE requires CUDA")
+    def test_gqa_cuda_parity(self, config):
+        """CUDA and CPU agree for GQA (n_kv_heads < n_heads)."""
+        from unturtle.models.dream.modeling_dream import _apply_dream_rope
+
+        torch.manual_seed(6)
+        B, n_heads, n_kv_heads, L, head_dim = 2, 8, 2, 16, 32
+
+        freqs = torch.randn(B, L, head_dim // 2)
+        cos = torch.cat([freqs.cos(), freqs.cos()], dim=-1)
+        sin = torch.cat([freqs.sin(), freqs.sin()], dim=-1)
+
+        q = torch.randn(B, n_heads, L, head_dim)
+        k = torch.randn(B, n_kv_heads, L, head_dim)
+
+        q_cpu, k_cpu = _apply_dream_rope(q.clone(), k.clone(), cos, sin, B, L)
+        q_cuda, k_cuda = _apply_dream_rope(
+            q.cuda().clone(), k.cuda().clone(), cos.cuda(), sin.cuda(), B, L
+        )
+
+        assert torch.allclose(q_cpu, q_cuda.cpu(), atol=1e-4), (
+            f"GQA Q mismatch: max_diff={(q_cpu - q_cuda.cpu()).abs().max().item():.2e}"
+        )
+        assert torch.allclose(k_cpu, k_cuda.cpu(), atol=1e-4), (
+            f"GQA K mismatch: max_diff={(k_cpu - k_cuda.cpu()).abs().max().item():.2e}"
+        )
+
+    def test_position_embeddings_none_fallback(self, config):
+        """DreamAttention_fast_forward computes RoPE internally when position_embeddings=None."""
+        import types
+        from unturtle.models.dream import DreamModel
+        from unturtle.models.dream.modeling_dream import DreamAttention_fast_forward
+
+        torch.manual_seed(9)
+        model = DreamModel(config).cpu().eval()
+
+        for module in model.modules():
+            if hasattr(module, "q_proj") and hasattr(module, "o_proj"):
+                if not hasattr(module, "apply_qkv"):
+                    from unturtle.fast_diffusion_model import _original_apply_qkv, _original_apply_o
+                    module.apply_qkv = _original_apply_qkv
+                    module.apply_o = _original_apply_o
+
+        for layer in model.model.layers:
+            layer.self_attn.forward = types.MethodType(
+                DreamAttention_fast_forward, layer.self_attn
+            )
+
+        B, L = 2, 16
+        input_ids = torch.randint(0, config.vocab_size, (B, L))
+        # DreamModel.forward computes and passes position_embeddings internally,
+        # but we verify the model still runs without error.
+        with torch.no_grad():
+            out = model(input_ids=input_ids)
+        assert out.logits.shape == (B, L, config.vocab_size)
+        assert not torch.isnan(out.logits).any()
+
+    def test_fast_forward_with_lora_dropout_still_works(self, config):
+        """DreamAttention_fast_forward is injected even when lora_dropout > 0.
+
+        The LoRA Triton kernels are skipped in that case, but the forward
+        (including Triton RoPE on CUDA) must still execute correctly.
+        """
+        import types
+        from unturtle.models.dream import DreamModel
+        from unturtle.models.dream.modeling_dream import DreamAttention_fast_forward
+
+        torch.manual_seed(11)
+        model = DreamModel(config).cpu().eval()
+
+        for module in model.modules():
+            if hasattr(module, "q_proj") and hasattr(module, "o_proj"):
+                if not hasattr(module, "apply_qkv"):
+                    from unturtle.fast_diffusion_model import _original_apply_qkv, _original_apply_o
+                    module.apply_qkv = _original_apply_qkv
+                    module.apply_o = _original_apply_o
+
+        # Inject forward manually (simulates what _patch_dream_peft does
+        # unconditionally before the lora_dropout check)
+        for layer in model.model.layers:
+            layer.self_attn.forward = types.MethodType(
+                DreamAttention_fast_forward, layer.self_attn
+            )
+
+        B, L = 2, 8
+        input_ids = torch.randint(0, config.vocab_size, (B, L))
+        with torch.no_grad():
+            out = model(input_ids=input_ids)
+        assert out.logits.shape == (B, L, config.vocab_size)
+        assert not torch.isnan(out.logits).any()

--- a/tests/models/test_dream.py
+++ b/tests/models/test_dream.py
@@ -101,3 +101,172 @@ class TestDreamGenerationUtils:
         from unturtle.models.dream import DreamGenerationMixin
         assert DreamGenerationMixin is not None
         assert hasattr(DreamGenerationMixin, "diffusion_generate")
+
+
+class TestDreamFastRoPE:
+    """Tests for DreamAttention_fast_forward Triton RoPE path."""
+
+    @pytest.fixture
+    def config(self):
+        from unturtle.models.dream import DreamConfig
+        return DreamConfig(
+            vocab_size=1000,
+            hidden_size=128,
+            intermediate_size=256,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            max_position_embeddings=128,
+            pad_token_id=0,
+            mask_token_id=1,
+        )
+
+    def test_fast_forward_importable(self):
+        from unturtle.models.dream.modeling_dream import DreamAttention_fast_forward
+        assert callable(DreamAttention_fast_forward)
+
+    def test_cpu_parity_simple(self, config):
+        """DreamAttention_fast_forward CPU fallback matches original forward."""
+        import types
+        from unturtle.models.dream import DreamModel
+        from unturtle.models.dream.modeling_dream import DreamAttention_fast_forward
+
+        torch.manual_seed(0)
+        model = DreamModel(config).cpu().eval()
+
+        B, L = 2, 16
+        input_ids = torch.randint(0, config.vocab_size, (B, L))
+
+        # Reference output (original forward)
+        with torch.no_grad():
+            ref_out = model(input_ids=input_ids)
+
+        # Install stubs and fast forward
+        for module in model.modules():
+            if hasattr(module, "q_proj") and hasattr(module, "o_proj"):
+                if not hasattr(module, "apply_qkv"):
+                    from unturtle.fast_diffusion_model import _original_apply_qkv, _original_apply_o
+                    module.apply_qkv = _original_apply_qkv
+                    module.apply_o = _original_apply_o
+
+        for layer in model.model.layers:
+            layer.self_attn.forward = types.MethodType(
+                DreamAttention_fast_forward, layer.self_attn
+            )
+
+        with torch.no_grad():
+            fast_out = model(input_ids=input_ids)
+
+        assert torch.allclose(ref_out.logits, fast_out.logits, atol=1e-5), (
+            f"CPU logits mismatch: max_diff={( ref_out.logits - fast_out.logits).abs().max().item():.2e}"
+        )
+
+    def test_cpu_parity_reset_position_ids(self, config):
+        """CPU fallback is numerically stable with non-monotonic position_ids (packed pattern)."""
+        import types
+        from unturtle.models.dream import DreamModel
+        from unturtle.models.dream.modeling_dream import DreamAttention_fast_forward, _apply_dream_rope
+
+        torch.manual_seed(1)
+        model = DreamModel(config).cpu().eval()
+
+        # Install stubs
+        for module in model.modules():
+            if hasattr(module, "q_proj") and hasattr(module, "o_proj"):
+                if not hasattr(module, "apply_qkv"):
+                    from unturtle.fast_diffusion_model import _original_apply_qkv, _original_apply_o
+                    module.apply_qkv = _original_apply_qkv
+                    module.apply_o = _original_apply_o
+
+        for layer in model.model.layers:
+            layer.self_attn.forward = types.MethodType(
+                DreamAttention_fast_forward, layer.self_attn
+            )
+
+        B, L = 2, 16
+        input_ids = torch.randint(0, config.vocab_size, (B, L))
+        # Reset position_ids: row 0 = [0..7, 0..7], row 1 = [0..15]
+        position_ids = torch.cat([
+            torch.arange(L // 2).repeat(2).unsqueeze(0),
+            torch.arange(L).unsqueeze(0),
+        ], dim=0)
+
+        with torch.no_grad():
+            out = model(input_ids=input_ids, position_ids=position_ids)
+        assert out.logits.shape == (B, L, config.vocab_size)
+        assert not torch.isnan(out.logits).any()
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Triton RoPE requires CUDA")
+    def test_cuda_parity_vs_cpu(self, config):
+        """CUDA fast_rope_embedding output matches CPU apply_rotary_pos_emb.
+
+        DreamRotaryEmbedding returns cos/sin via cat(freqs, freqs) so the
+        first and second halves are identical — this is the format that
+        fast_rope_embedding requires (it only reads head_dim//2 elements).
+        """
+        from unturtle.models.dream.modeling_dream import _apply_dream_rope
+
+        torch.manual_seed(42)
+        B, n_heads, L, head_dim = 2, 4, 16, 32
+
+        # Simulate DreamRotaryEmbedding output: cat(freqs, freqs) pattern
+        freqs = torch.randn(B, L, head_dim // 2)
+        cos = torch.cat([freqs.cos(), freqs.cos()], dim=-1)  # (B, L, head_dim)
+        sin = torch.cat([freqs.sin(), freqs.sin()], dim=-1)
+
+        q = torch.randn(B, n_heads, L, head_dim)
+        k = torch.randn(B, n_heads, L, head_dim)
+
+        # CPU reference (clone: fast_rope_embedding is in-place on CUDA)
+        q_cpu, k_cpu = _apply_dream_rope(q.clone(), k.clone(), cos, sin, B, L)
+
+        # CUDA fast path
+        q_cuda, k_cuda = _apply_dream_rope(
+            q.cuda().clone(), k.cuda().clone(), cos.cuda(), sin.cuda(), B, L
+        )
+
+        assert torch.allclose(q_cpu, q_cuda.cpu(), atol=1e-4), (
+            f"Q mismatch: max_diff={(q_cpu - q_cuda.cpu()).abs().max().item():.2e}"
+        )
+        assert torch.allclose(k_cpu, k_cuda.cpu(), atol=1e-4), (
+            f"K mismatch: max_diff={(k_cpu - k_cuda.cpu()).abs().max().item():.2e}"
+        )
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="Triton RoPE requires CUDA")
+    def test_cuda_no_double_index_reset_positions(self, config):
+        """CUDA path with reset position_ids produces valid output (no NaN, correct shape).
+
+        cos/sin use the cat(freqs, freqs) pattern from DreamRotaryEmbedding
+        and are pre-indexed per batch row to simulate packed/reset positions.
+        """
+        from unturtle.models.dream.modeling_dream import _apply_dream_rope
+
+        torch.manual_seed(7)
+        B, n_heads, L, head_dim = 2, 4, 8, 32
+
+        q = torch.randn(B, n_heads, L, head_dim).cuda()
+        k = torch.randn(B, n_heads, L, head_dim).cuda()
+
+        # DreamRotaryEmbedding-style cos/sin: cat(freqs, freqs) pattern
+        freqs = torch.randn(B, L, head_dim // 2).cuda()
+        cos = torch.cat([freqs.cos(), freqs.cos()], dim=-1)
+        sin = torch.cat([freqs.sin(), freqs.sin()], dim=-1)
+
+        # Clone before passing to each path (fast_rope_embedding is in-place)
+        q_cuda_in = q.clone()
+        k_cuda_in = k.clone()
+        q_cpu_in = q.cpu().clone()
+        k_cpu_in = k.cpu().clone()
+
+        with torch.no_grad():
+            q_out, k_out = _apply_dream_rope(q_cuda_in, k_cuda_in, cos, sin, B, L)
+            q_cpu, k_cpu = _apply_dream_rope(q_cpu_in, k_cpu_in, cos.cpu(), sin.cpu(), B, L)
+
+        assert q_out.shape == q.shape
+        assert k_out.shape == k.shape
+        assert not torch.isnan(q_out).any()
+        assert not torch.isnan(k_out).any()
+
+        assert torch.allclose(q_cpu, q_out.cpu(), atol=1e-4), (
+            f"CUDA/CPU parity failed: max_diff={(q_cpu - q_out.cpu()).abs().max().item():.2e}"
+        )

--- a/tests/test_fast_diffusion_model.py
+++ b/tests/test_fast_diffusion_model.py
@@ -169,7 +169,7 @@ class TestGetPeftModel:
         """After get_peft_model, apply_qkv on attention layers should be
         apply_lora_qkv (the Triton kernel) when lora_dropout=0 and bias='none'.
         """
-        from unsloth.kernels.fast_lora import apply_lora_qkv
+        from unturtle.kernels.fast_lora import apply_lora_qkv
 
         from unturtle.fast_diffusion_model import FastDiffusionModel
 
@@ -189,7 +189,7 @@ class TestGetPeftModel:
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="Triton kernels require CUDA")
     def test_apply_o_patched_to_lora(self, tiny_model):
-        from unsloth.kernels.fast_lora import apply_lora_o
+        from unturtle.kernels.fast_lora import apply_lora_o
 
         from unturtle.fast_diffusion_model import FastDiffusionModel
 
@@ -525,7 +525,7 @@ class TestDreamPatching:
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="Triton kernels require CUDA")
     def test_dream_peft_o_proj_patched(self, tiny_dream_model):
         """After get_peft_model, o_proj layers should have apply_o=apply_lora_o."""
-        from unsloth.kernels.fast_lora import apply_lora_o
+        from unturtle.kernels.fast_lora import apply_lora_o
         from unturtle.fast_diffusion_model import FastDiffusionModel
 
         peft_model = FastDiffusionModel.get_peft_model(
@@ -620,7 +620,7 @@ class TestLLaDAPatching:
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="Triton kernels require CUDA")
     def test_llada_peft_attn_out_patched(self, tiny_llada_model):
         """After get_peft_model, attn_out in LLaDALlamaBlocks should have apply_o=apply_lora_o."""
-        from unsloth.kernels.fast_lora import apply_lora_o
+        from unturtle.kernels.fast_lora import apply_lora_o
         from unturtle.fast_diffusion_model import FastDiffusionModel
 
         peft_model = FastDiffusionModel.get_peft_model(
@@ -644,7 +644,7 @@ class TestLLaDAPatching:
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="Triton kernels require CUDA")
     def test_llada_peft_qkv_patched(self, tiny_llada_model):
         """LLaDALlamaBlock q/k/v_proj without bias should get apply_qkv=apply_lora_qkv."""
-        from unsloth.kernels.fast_lora import apply_lora_qkv
+        from unturtle.kernels.fast_lora import apply_lora_qkv
         from unturtle.fast_diffusion_model import FastDiffusionModel
 
         peft_model = FastDiffusionModel.get_peft_model(

--- a/tests/utils/test_attention_masks.py
+++ b/tests/utils/test_attention_masks.py
@@ -19,8 +19,8 @@ import math
 
 import torch
 
-from unsloth.utils import attention_dispatch
-from unsloth.utils import packing as packing_utils
+from unturtle.utils import attention_dispatch
+from unturtle.utils import packing as packing_utils
 
 
 def _make_seq_info(lengths):

--- a/tests/utils/test_packing.py
+++ b/tests/utils/test_packing.py
@@ -15,7 +15,7 @@
 
 from unsloth import FastLanguageModel
 from unsloth.utils import attention_dispatch as attention_dispatch_utils
-from unsloth.utils.packing import (
+from unturtle.utils.packing import (
     configure_padding_free,
     configure_sample_packing,
     enable_padding_free_metadata,

--- a/unturtle/__init__.py
+++ b/unturtle/__init__.py
@@ -37,87 +37,95 @@ Target state (Phase Z — full migration, no unsloth dependency):
   CLAUDE.md §「unsloth 完全移行チェックリスト」when it is decoupled.
 """
 
-from unsloth import *  # noqa: F401, F403  # TODO(Phase Z): remove after full migration
-from unsloth import __version__  # noqa: F401
+import sys
 
-# ---------------------------------------------------------------------------
-# dLLM training stack — canonical source is unturtle.*
-# ---------------------------------------------------------------------------
-from unturtle.diffusion import (  # noqa: F401
-    BaseAlphaScheduler,
-    CosineAlphaScheduler,
-    DiffusionTrainer,
-    DiffusionTrainingArguments,
-    DiffuGRPOTrainer,
-    DiffuGRPOConfig,
-    LinearAlphaScheduler,
-    MaskedDiffusionDataCollator,
-    PackedMaskedDiffusionDataCollator,
-    make_alpha_scheduler,
-)
-from unturtle.kernels.masked_diffusion_loss import (  # noqa: F401
-    fast_masked_diffusion_loss,
-    masked_diffusion_loss_from_timesteps,
-)
-from unturtle.kernels.fused_masked_diffusion_loss import (  # noqa: F401
-    fused_masked_diffusion_loss,
-)
-from unturtle.fast_diffusion_model import FastDiffusionModel  # noqa: F401
-from unturtle.eval import (  # noqa: F401
-    BaseEvaluator,
-    GenerationEvaluator,
-    MaskedDiffusionEvaluator,
+
+_unsloth_module = sys.modules.get("unsloth")
+_UNSLOTH_BOOTSTRAPPING = _unsloth_module is not None and not hasattr(
+    _unsloth_module, "is_bfloat16_supported"
 )
 
-# ---------------------------------------------------------------------------
-# dLLM model classes
-# ---------------------------------------------------------------------------
-from unturtle.models import (  # noqa: F401
-    A2DLlamaConfig,
-    A2DLlamaModel,
-    A2DLlamaLMHeadModel,
-    A2DModernBertConfig,
-    A2DModernBertModel,
-    A2DModernBertForMaskedLM,
-    A2DQwen2Config,
-    A2DQwen2Model,
-    A2DQwen2LMHeadModel,
-    A2DQwen3Config,
-    A2DQwen3Model,
-    A2DQwen3LMHeadModel,
-    LLaDAConfig,
-    LLaDAModel,
-    LLaDAModelLM,
-    DreamConfig,
-    DreamModel,
-    DreamGenerationMixin,
-    DreamGenerationConfig,
-)
-# Alias for discoverability — DreamModel is the full masked-diffusion model
-DreamForDiffusionLM = DreamModel  # noqa: F401
+__version__ = getattr(_unsloth_module, "__version__", "0.0.0")
 
-# ---------------------------------------------------------------------------
-# Optimizers
-# Re-export unsloth optimizers when available so users can write
-#   from unturtle import QGaLoreAdamW8bit
-# instead of reaching into unsloth directly.
-# TODO(Phase Z): once unsloth dependency is removed, vendor or reimplement
-#   these optimizers inside unturtle.optimizers and update these imports.
-# ---------------------------------------------------------------------------
-try:
-    from unsloth.optimizers import (  # noqa: F401
-        GaLoreProjector,
-        QGaLoreAdamW8bit,
+if not _UNSLOTH_BOOTSTRAPPING:
+    from unsloth import *  # noqa: F401, F403  # TODO(Phase Z): remove after full migration
+
+    # ---------------------------------------------------------------------------
+    # dLLM training stack — canonical source is unturtle.*
+    # ---------------------------------------------------------------------------
+    from unturtle.diffusion import (  # noqa: F401
+        BaseAlphaScheduler,
+        CosineAlphaScheduler,
+        DiffusionTrainer,
+        DiffusionTrainingArguments,
+        DiffuGRPOTrainer,
+        DiffuGRPOConfig,
+        LinearAlphaScheduler,
+        MaskedDiffusionDataCollator,
+        PackedMaskedDiffusionDataCollator,
+        make_alpha_scheduler,
     )
-except (ImportError, AttributeError):
-    pass  # Older unsloth versions that do not expose these symbols
-
-# UnslothAdamW family — available in newer unsloth releases
-try:
-    from unsloth.optimizers import (  # noqa: F401
-        UnslothAdamW,
-        UnslothAdamW8bit,
-        UnslothAdamWScheduleFree,
+    from unturtle.kernels.masked_diffusion_loss import (  # noqa: F401
+        fast_masked_diffusion_loss,
+        masked_diffusion_loss_from_timesteps,
     )
-except (ImportError, AttributeError):
-    pass
+    from unturtle.kernels.fused_masked_diffusion_loss import (  # noqa: F401
+        fused_masked_diffusion_loss,
+    )
+    from unturtle.fast_diffusion_model import FastDiffusionModel  # noqa: F401
+    from unturtle.eval import (  # noqa: F401
+        BaseEvaluator,
+        GenerationEvaluator,
+        MaskedDiffusionEvaluator,
+    )
+
+    # ---------------------------------------------------------------------------
+    # dLLM model classes
+    # ---------------------------------------------------------------------------
+    from unturtle.models import (  # noqa: F401
+        A2DLlamaConfig,
+        A2DLlamaModel,
+        A2DLlamaLMHeadModel,
+        A2DModernBertConfig,
+        A2DModernBertModel,
+        A2DModernBertForMaskedLM,
+        A2DQwen2Config,
+        A2DQwen2Model,
+        A2DQwen2LMHeadModel,
+        A2DQwen3Config,
+        A2DQwen3Model,
+        A2DQwen3LMHeadModel,
+        LLaDAConfig,
+        LLaDAModel,
+        LLaDAModelLM,
+        DreamConfig,
+        DreamModel,
+        DreamGenerationMixin,
+        DreamGenerationConfig,
+    )
+    DreamForDiffusionLM = DreamModel  # noqa: F401
+
+    # ---------------------------------------------------------------------------
+    # Optimizers
+    # Re-export unsloth optimizers when available so users can write
+    #   from unturtle import QGaLoreAdamW8bit
+    # instead of reaching into unsloth directly.
+    # TODO(Phase Z): once unsloth dependency is removed, vendor or reimplement
+    #   these optimizers inside unturtle.optimizers and update these imports.
+    # ---------------------------------------------------------------------------
+    try:
+        from unsloth.optimizers import (  # noqa: F401
+            GaLoreProjector,
+            QGaLoreAdamW8bit,
+        )
+    except (ImportError, AttributeError):
+        pass  # Older unsloth versions that do not expose these symbols
+
+    try:
+        from unsloth.optimizers import (  # noqa: F401
+            UnslothAdamW,
+            UnslothAdamW8bit,
+            UnslothAdamWScheduleFree,
+        )
+    except (ImportError, AttributeError):
+        pass

--- a/unturtle/diffusion/trainer.py
+++ b/unturtle/diffusion/trainer.py
@@ -39,7 +39,7 @@ from typing import Any
 
 import torch
 
-from unsloth.trainer import UnslothTrainer, UnslothTrainingArguments
+from unturtle.trainer import UnslothTrainer, UnslothTrainingArguments
 from unturtle.eval import GenerationEvaluator, MaskedDiffusionEvaluator
 from unturtle.kernels.masked_diffusion_loss import fast_masked_diffusion_loss
 

--- a/unturtle/fast_diffusion_model.py
+++ b/unturtle/fast_diffusion_model.py
@@ -74,8 +74,7 @@ except (ImportError, OSError, AttributeError) as exc:
 else:
     _FAST_LORA_IMPORT_ERROR = None
 
-from unsloth.models._utils import prepare_model_for_kbit_training
-from unsloth.save import patch_saving_functions
+from unturtle.save import patch_saving_functions, prepare_model_for_kbit_training
 
 from unturtle.models.a2d._fast_forward import (
     A2DAttention_fast_forward,

--- a/unturtle/fast_diffusion_model.py
+++ b/unturtle/fast_diffusion_model.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 
 import contextlib
 import functools
+import importlib
 import logging
 import types
 from typing import Any, Literal, Optional
@@ -57,12 +58,22 @@ from peft import LoraConfig, TaskType, get_peft_model
 from peft.tuners.lora import Linear as LoraLinear
 from transformers import AutoConfig, AutoTokenizer
 
-from unsloth.kernels.fast_lora import (
-    apply_lora_mlp_swiglu,
-    apply_lora_o,
-    apply_lora_qkv,
-)
-from unturtle.kernels.fast_lora import apply_lora_qkv_with_bias
+try:
+    from unturtle.kernels.fast_lora import (
+        apply_lora_mlp_swiglu,
+        apply_lora_o,
+        apply_lora_qkv,
+        apply_lora_qkv_with_bias,
+    )
+except (ImportError, OSError, AttributeError) as exc:
+    apply_lora_mlp_swiglu = None
+    apply_lora_o = None
+    apply_lora_qkv = None
+    apply_lora_qkv_with_bias = None
+    _FAST_LORA_IMPORT_ERROR = exc
+else:
+    _FAST_LORA_IMPORT_ERROR = None
+
 from unsloth.models._utils import prepare_model_for_kbit_training
 from unsloth.save import patch_saving_functions
 
@@ -73,6 +84,14 @@ from unturtle.models.a2d._fast_forward import (
 )
 
 _logger = logging.getLogger(__name__)
+
+
+def _require_fast_lora() -> None:
+    if _FAST_LORA_IMPORT_ERROR is not None:
+        raise ImportError(
+            "FastDiffusionModel requires unturtle.kernels.fast_lora and its optional "
+            "bitsandbytes-backed dependencies to be importable."
+        ) from _FAST_LORA_IMPORT_ERROR
 
 
 def _warn_once(msg: str) -> None:
@@ -120,6 +139,9 @@ def _patch_a2d_peft(model: Any, lora_dropout: float, bias: Literal["none", "all"
     # Triton kernels and flash attention require the model to be on CUDA.
     first_param = next(iter(model.parameters()), None)
     on_cuda = first_param is not None and first_param.device.type == "cuda"
+
+    if on_cuda and lora_dropout == 0 and bias == "none":
+        _require_fast_lora()
 
     for layer in layers:
         # --- fast attention (bidirectional) — GPU only ---
@@ -215,6 +237,9 @@ def _patch_dream_peft(
         return n_qkv, n_o, n_mlp
 
     layers = model.base_model.model.model.layers
+
+    if lora_dropout == 0 and bias == "none":
+        _require_fast_lora()
 
     for layer in layers:
         self_attn = layer.self_attn if hasattr(layer, "self_attn") else None
@@ -329,6 +354,9 @@ def _patch_llada_peft(
         return n_qkv, n_o, n_mlp
 
     blocks = transformer.blocks
+
+    if lora_dropout == 0 and bias == "none":
+        _require_fast_lora()
 
     for block in blocks:
         if not isinstance(block, LLaDALlamaBlock):
@@ -449,6 +477,9 @@ def _patch_modernbert_peft(
     if not on_cuda:
         return 0, 0, 0
 
+    if lora_dropout == 0 and bias == "none":
+        _require_fast_lora()
+
     for layer in layers:
         attn = getattr(layer, "attn", None)
         if attn is None:
@@ -488,6 +519,29 @@ def _no_bias(proj: Any) -> bool:
 
 def _no_lora_mag(proj: Any) -> bool:
     return len(getattr(proj, "lora_magnitude_vector", []) or []) == 0
+
+
+def _load_model_with_optional_4bit_fallback(
+    loader: Any,
+    model_name: str,
+    load_kwargs: dict[str, Any],
+) -> Any:
+    try:
+        return loader.from_pretrained(model_name, **load_kwargs)
+    except Exception as exc:  # noqa: BLE001
+        if "quantization_config" not in load_kwargs:
+            raise
+
+        fallback_kwargs = dict(load_kwargs)
+        fallback_kwargs.pop("quantization_config", None)
+        fallback_kwargs.pop("device_map", None)
+        _warn_once(
+            "FastDiffusionModel: 4-bit loading failed — retrying with full-precision loading."
+        )
+        _logger.debug(
+            "FastDiffusionModel: retrying without 4-bit quantization after error: %s", exc
+        )
+        return loader.from_pretrained(model_name, **fallback_kwargs)
 
 
 def _load_model_auto(model_name: str, load_kwargs: dict, trust_remote_code: bool) -> Any:
@@ -533,7 +587,7 @@ def _load_model_auto(model_name: str, load_kwargs: dict, trust_remote_code: bool
                 "FastDiffusionModel: using native unturtle class %s for model_type=%r",
                 native_cls.__name__, model_type,
             )
-            return native_cls.from_pretrained(model_name, **load_kwargs)
+            return _load_model_with_optional_4bit_fallback(native_cls, model_name, load_kwargs)
     except torch.cuda.OutOfMemoryError:
         raise  # OOM should propagate, not fall through to slower AutoModel loaders
     except Exception as exc:  # noqa: BLE001
@@ -547,7 +601,9 @@ def _load_model_auto(model_name: str, load_kwargs: dict, trust_remote_code: bool
     last_exc: Exception | None = None
     for name, loader_cls in loaders:
         try:
-            return loader_cls.from_pretrained(model_name, **load_kwargs)
+            return _load_model_with_optional_4bit_fallback(
+                loader_cls, model_name, load_kwargs
+            )
         except Exception as exc:  # noqa: BLE001
             _logger.debug("FastDiffusionModel: %s failed: %s", name, exc)
             last_exc = exc
@@ -684,23 +740,28 @@ class FastDiffusionModel:
 
         # --- 4-bit quantisation (CUDA only) ---
         if load_in_4bit and not is_on_cpu:
-            try:
-                from transformers import BitsAndBytesConfig
-
-                bnb_config = BitsAndBytesConfig(
-                    load_in_4bit=True,
-                    bnb_4bit_quant_type="nf4",
-                    bnb_4bit_compute_dtype=dtype,
-                    bnb_4bit_use_double_quant=True,
-                )
-                load_kwargs["quantization_config"] = bnb_config
-                # device_map="auto" is required for multi-GPU or when GPU 0 is partially occupied.
-                if "device_map" not in load_kwargs:
-                    load_kwargs["device_map"] = "auto"
-            except ImportError:
+            if importlib.util.find_spec("bitsandbytes") is None:
                 _warn_once(
                     "bitsandbytes not installed — falling back to full-precision loading."
                 )
+            else:
+                try:
+                    from transformers import BitsAndBytesConfig
+
+                    bnb_config = BitsAndBytesConfig(
+                        load_in_4bit=True,
+                        bnb_4bit_quant_type="nf4",
+                        bnb_4bit_compute_dtype=dtype,
+                        bnb_4bit_use_double_quant=True,
+                    )
+                    load_kwargs["quantization_config"] = bnb_config
+                    # device_map="auto" is required for multi-GPU or when GPU 0 is partially occupied.
+                    if "device_map" not in load_kwargs:
+                        load_kwargs["device_map"] = "auto"
+                except ImportError:
+                    _warn_once(
+                        "bitsandbytes not installed — falling back to full-precision loading."
+                    )
         elif load_in_4bit and is_on_cpu:
             _warn_once(
                 "FastDiffusionModel: load_in_4bit=True requires CUDA — "

--- a/unturtle/fast_diffusion_model.py
+++ b/unturtle/fast_diffusion_model.py
@@ -81,6 +81,7 @@ from unturtle.models.a2d._fast_forward import (
     ModernBertAttention_fast_forward,
     _install_modernbert_stubs,
 )
+from unturtle.models.dream.modeling_dream import DreamAttention_fast_forward
 
 _logger = logging.getLogger(__name__)
 
@@ -242,6 +243,10 @@ def _patch_dream_peft(
 
     for layer in layers:
         self_attn = layer.self_attn if hasattr(layer, "self_attn") else None
+
+        # Inject Triton RoPE fast forward unconditionally (CUDA already checked above)
+        if self_attn is not None:
+            self_attn.forward = types.MethodType(DreamAttention_fast_forward, self_attn)
 
         if lora_dropout != 0 or bias != "none":
             continue

--- a/unturtle/kernels/__init__.py
+++ b/unturtle/kernels/__init__.py
@@ -14,32 +14,64 @@
 
 """unturtle.kernels — Triton-optimised kernels for dLLM training.
 
-Canonical home for unturtle-specific kernels.  The underlying CE kernel
-(``Fast_CrossEntropyLoss``) remains in ``unsloth.kernels`` to stay in sync
-with upstream unslothai/unsloth.
+Canonical home for unturtle-specific kernels vendored or extended for unturtle.
 
 Public API::
 
-    from unturtle.kernels.masked_diffusion_loss import (
+    from unturtle.kernels import (
+        Fast_CrossEntropyLoss,
+        LoRA_QKV,
+        LoRA_QKV_Bias,
+        apply_lora_o,
+        apply_lora_qkv,
+        apply_lora_qkv_with_bias,
+        apply_lora_mlp_swiglu,
+        fast_cross_entropy_loss,
         fast_masked_diffusion_loss,
+        fast_rope_embedding,
+        fused_masked_diffusion_loss,
         masked_diffusion_loss_from_timesteps,
     )
 """
 
+from .cross_entropy_loss import Fast_CrossEntropyLoss, fast_cross_entropy_loss
 from .masked_diffusion_loss import (
     fast_masked_diffusion_loss,
     masked_diffusion_loss_from_timesteps,
 )
 from .fused_masked_diffusion_loss import fused_masked_diffusion_loss
-from .fast_lora import (
-    LoRA_QKV_Bias,
-    apply_lora_qkv_with_bias,
-)
+from .rope_embedding import fast_rope_embedding
 
 __all__ = [
+    "Fast_CrossEntropyLoss",
+    "fast_cross_entropy_loss",
     "fast_masked_diffusion_loss",
     "masked_diffusion_loss_from_timesteps",
     "fused_masked_diffusion_loss",
-    "LoRA_QKV_Bias",
-    "apply_lora_qkv_with_bias",
+    "fast_rope_embedding",
 ]
+
+try:
+    from .fast_lora import (
+        LoRA_QKV,
+        LoRA_QKV_Bias,
+        apply_lora_mlp_swiglu,
+        apply_lora_o,
+        apply_lora_qkv,
+        apply_lora_qkv_with_bias,
+    )
+except (ImportError, OSError, AttributeError):
+    # fast_lora has optional bitsandbytes-backed dependencies; keep the rest of
+    # unturtle.kernels importable when they are unavailable or partially linked.
+    pass
+else:
+    __all__.extend(
+        [
+            "LoRA_QKV",
+            "LoRA_QKV_Bias",
+            "apply_lora_qkv",
+            "apply_lora_qkv_with_bias",
+            "apply_lora_o",
+            "apply_lora_mlp_swiglu",
+        ]
+    )

--- a/unturtle/kernels/_fast_lora_core.py
+++ b/unturtle/kernels/_fast_lora_core.py
@@ -1,0 +1,533 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Vendored from unsloth/kernels/fast_lora.py for issue #67.
+
+from __future__ import annotations
+
+import torch
+
+from ._fast_lora_utils import (
+    QUANT_STATE,
+    _maybe_fake_quantize_activations,
+    fast_dequantize,
+    get_lora_parameters,
+    matmul_lora,
+    torch_amp_custom_bwd,
+    torch_amp_custom_fwd,
+)
+from ._geglu import (
+    geglu_approx_backward_kernel,
+    geglu_approx_forward_kernel,
+    geglu_exact_backward_kernel,
+    geglu_exact_forward_kernel,
+)
+from ._swiglu import swiglu_DWf_DW_dfg_kernel, swiglu_fg_kernel
+
+
+class LoRA_MLP(torch.autograd.Function):
+    @staticmethod
+    @torch_amp_custom_fwd
+    def forward(
+        ctx,
+        X: torch.Tensor,
+        gateW,
+        gateW_quant,
+        gateA,
+        gateB,
+        gateS,
+        upW,
+        upW_quant,
+        upA,
+        upB,
+        upS,
+        downW,
+        downW_quant,
+        downA,
+        downB,
+        downS,
+        _forward_function,
+        _backward_function,
+        inplace=True,
+    ):
+        e = matmul_lora(X, gateW, gateW_quant, gateA, gateB, gateS)
+        g = matmul_lora(X, upW, upW_quant, upA, upB, upS)
+        h = _forward_function(e, g)
+        i = matmul_lora(h, downW, downW_quant, downA, downB, downS)
+
+        ctx.custom_saved_tensors = (
+            gateW,
+            gateW_quant,
+            gateS,
+            upW,
+            upW_quant,
+            upS,
+            downW,
+            downW_quant,
+            downS,
+            _backward_function,
+        )
+        ctx.save_for_backward(gateA, gateB, upA, upB, downA, downB, X, e, g)
+        ctx.inplace = inplace
+        return i
+
+    @staticmethod
+    @torch_amp_custom_bwd
+    def backward(ctx, dY: torch.Tensor):
+        (
+            gateW,
+            gateW_quant,
+            gateS,
+            upW,
+            upW_quant,
+            upS,
+            downW,
+            downW_quant,
+            downS,
+            _backward_function,
+        ) = ctx.custom_saved_tensors
+        gateA, gateB, upA, upB, downA, downB, X, e, g = ctx.saved_tensors
+
+        batch, seq_len, hd = X.shape
+        dY = dY.view(-1, dY.shape[-1])
+        X = X.view(-1, X.shape[-1])
+        e = e.view(-1, e.shape[-1])
+        g = g.view(-1, g.shape[-1])
+        dtype = X.dtype
+
+        gateA, gateB, upA, upB, downA, downB = (
+            gateA.to(dtype),
+            gateB.to(dtype),
+            upA.to(dtype),
+            upB.to(dtype),
+            downA.to(dtype),
+            downB.to(dtype),
+        )
+        gateA, gateB, upA, upB, downA, downB = (
+            gateA.t(),
+            gateB.t(),
+            upA.t(),
+            upB.t(),
+            downA.t(),
+            downB.t(),
+        )
+
+        DW = matmul_lora(dY, downW.t(), downW_quant, downB, downA, downS)
+        DW, e, g = _backward_function(DW, e, g)
+        h, df, de = DW, e, g
+
+        d_downA = torch.empty_like(downA)
+        d_downB = torch.empty_like(downB)
+        d_gateA = torch.empty_like(gateA)
+        d_gateB = torch.empty_like(gateB)
+        d_upA = torch.empty_like(upA)
+        d_upB = torch.empty_like(upB)
+
+        d_downA.addmm_(h.t(), dY @ downB.t(), alpha=downS, beta=0)
+        d_downB.addmm_(downA.t() @ h.t(), dY, alpha=downS, beta=0)
+
+        d_upA.addmm_(X.t(), df @ upB.t(), alpha=upS, beta=0)
+        d_upB.addmm_(upA.t() @ X.t(), df, alpha=upS, beta=0)
+
+        d_gateA.addmm_(X.t(), de @ gateB.t(), alpha=gateS, beta=0)
+        d_gateB.addmm_(gateA.t() @ X.t(), de, alpha=gateS, beta=0)
+
+        upW = fast_dequantize(upW.t(), upW_quant)
+        dX = torch.matmul(df, upW.t(), out=X if ctx.inplace else None)
+        del upW
+        dX.addmm_(df @ upB.t(), upA.t(), alpha=upS)
+
+        gateW = fast_dequantize(gateW.t(), gateW_quant)
+        dX.addmm_(de, gateW.t())
+        del gateW
+        dX.addmm_(de @ gateB.t(), gateA.t(), alpha=gateS)
+
+        return (
+            dX.view(batch, seq_len, hd),
+            None,
+            None,
+            d_gateA.t(),
+            d_gateB.t(),
+            None,
+            None,
+            None,
+            d_upA.t(),
+            d_upB.t(),
+            None,
+            None,
+            None,
+            d_downA.t(),
+            d_downB.t(),
+            None,
+            None,
+            None,
+            None,
+        )
+
+
+def apply_lora_mlp_swiglu(self, X, inplace=True):
+    X = _maybe_fake_quantize_activations(X, self.gate_proj)
+    gateW, gateW_quant, gateA, gateB, gateS = get_lora_parameters(self.gate_proj)
+    upW, upW_quant, upA, upB, upS = get_lora_parameters(self.up_proj)
+    downW, downW_quant, downA, downB, downS = get_lora_parameters(self.down_proj)
+    out = LoRA_MLP.apply(
+        X,
+        gateW,
+        gateW_quant,
+        gateA,
+        gateB,
+        gateS,
+        upW,
+        upW_quant,
+        upA,
+        upB,
+        upS,
+        downW,
+        downW_quant,
+        downA,
+        downB,
+        downS,
+        swiglu_fg_kernel,
+        swiglu_DWf_DW_dfg_kernel,
+        inplace,
+    )
+    return out
+
+
+def apply_lora_mlp_geglu_exact(self, X, inplace=True):
+    X = _maybe_fake_quantize_activations(X, self.gate_proj)
+    gateW, gateW_quant, gateA, gateB, gateS = get_lora_parameters(self.gate_proj)
+    upW, upW_quant, upA, upB, upS = get_lora_parameters(self.up_proj)
+    downW, downW_quant, downA, downB, downS = get_lora_parameters(self.down_proj)
+    out = LoRA_MLP.apply(
+        X,
+        gateW,
+        gateW_quant,
+        gateA,
+        gateB,
+        gateS,
+        upW,
+        upW_quant,
+        upA,
+        upB,
+        upS,
+        downW,
+        downW_quant,
+        downA,
+        downB,
+        downS,
+        geglu_exact_forward_kernel,
+        geglu_exact_backward_kernel,
+        inplace,
+    )
+    return out
+
+
+def apply_lora_mlp_geglu_approx(self, X):
+    X = _maybe_fake_quantize_activations(X, self.gate_proj)
+    gateW, gateW_quant, gateA, gateB, gateS = get_lora_parameters(self.gate_proj)
+    upW, upW_quant, upA, upB, upS = get_lora_parameters(self.up_proj)
+    downW, downW_quant, downA, downB, downS = get_lora_parameters(self.down_proj)
+    out = LoRA_MLP.apply(
+        X,
+        gateW,
+        gateW_quant,
+        gateA,
+        gateB,
+        gateS,
+        upW,
+        upW_quant,
+        upA,
+        upB,
+        upS,
+        downW,
+        downW_quant,
+        downA,
+        downB,
+        downS,
+        geglu_approx_forward_kernel,
+        geglu_approx_backward_kernel,
+    )
+    return out
+
+
+class LoRA_QKV(torch.autograd.Function):
+    @staticmethod
+    @torch_amp_custom_fwd
+    def forward(
+        ctx,
+        X: torch.Tensor,
+        QW,
+        QW_quant,
+        QA,
+        QB,
+        QS,
+        KW,
+        KW_quant,
+        KA,
+        KB,
+        KS,
+        VW,
+        VW_quant,
+        VA,
+        VB,
+        VS,
+        inplace=True,
+    ):
+        orig_shape = X.shape
+        X_for_matmul = X
+        if X.dim() == 3:
+            X_for_matmul = X.view(-1, X.shape[-1])
+        Q = matmul_lora(X_for_matmul, QW, QW_quant, QA, QB, QS)
+        K = matmul_lora(X_for_matmul, KW, KW_quant, KA, KB, KS)
+        V = matmul_lora(X_for_matmul, VW, VW_quant, VA, VB, VS)
+
+        if len(orig_shape) == 3:
+            Q = Q.view(orig_shape[0], orig_shape[1], -1)
+            K = K.view(orig_shape[0], orig_shape[1], -1)
+            V = V.view(orig_shape[0], orig_shape[1], -1)
+
+        ctx.custom_saved_tensors = (
+            QW,
+            QW_quant,
+            QS,
+            KW,
+            KW_quant,
+            KS,
+            VW,
+            VW_quant,
+            VS,
+        )
+        ctx.save_for_backward(X, QA, QB, KA, KB, VA, VB)
+        ctx.inplace = inplace
+        return Q, K, V
+
+    @staticmethod
+    @torch_amp_custom_bwd
+    def backward(ctx, dQ, dK, dV):
+        QW, QW_quant, QS, KW, KW_quant, KS, VW, VW_quant, VS = ctx.custom_saved_tensors
+        X, QA, QB, KA, KB, VA, VB = ctx.saved_tensors
+
+        batch, seq_len, hd = X.shape
+        dQ = dQ.view(-1, dQ.shape[-1])
+        dK = dK.reshape(-1, dK.shape[-1])
+        dV = dV.view(-1, dV.shape[-1])
+        X = X.view(-1, X.shape[-1])
+        dtype = X.dtype
+
+        QA, QB, KA, KB, VA, VB = (
+            QA.to(dtype),
+            QB.to(dtype),
+            KA.to(dtype),
+            KB.to(dtype),
+            VA.to(dtype),
+            VB.to(dtype),
+        )
+        QA, QB, KA, KB, VA, VB = QA.t(), QB.t(), KA.t(), KB.t(), VA.t(), VB.t()
+
+        d_QA = torch.empty_like(QA)
+        d_QB = torch.empty_like(QB)
+        d_KA = torch.empty_like(KA)
+        d_KB = torch.empty_like(KB)
+        d_VA = torch.empty_like(VA)
+        d_VB = torch.empty_like(VB)
+
+        d_QA.addmm_(X.t(), dQ @ QB.t(), alpha=QS, beta=0)
+        d_QB.addmm_(QA.t() @ X.t(), dQ, alpha=QS, beta=0)
+        d_KA.addmm_(X.t(), dK @ KB.t(), alpha=KS, beta=0)
+        d_KB.addmm_(KA.t() @ X.t(), dK, alpha=KS, beta=0)
+        d_VA.addmm_(X.t(), dV @ VB.t(), alpha=VS, beta=0)
+        d_VB.addmm_(VA.t() @ X.t(), dV, alpha=VS, beta=0)
+
+        QW = fast_dequantize(QW.t(), QW_quant)
+        dX = torch.matmul(dQ, QW.t(), out=X if ctx.inplace else None)
+        del QW
+        dX.addmm_(dQ @ QB.t(), QA.t(), alpha=QS)
+
+        KW = fast_dequantize(KW.t(), KW_quant)
+        dX.addmm_(dK, KW.t())
+        del KW
+        dX.addmm_(dK @ KB.t(), KA.t(), alpha=KS)
+
+        VW = fast_dequantize(VW.t(), VW_quant)
+        dX.addmm_(dV, VW.t())
+        del VW
+        dX.addmm_(dV @ VB.t(), VA.t(), alpha=VS)
+
+        return (
+            dX.view(batch, seq_len, hd),
+            None,
+            None,
+            d_QA.t(),
+            d_QB.t(),
+            None,
+            None,
+            None,
+            d_KA.t(),
+            d_KB.t(),
+            None,
+            None,
+            None,
+            d_VA.t(),
+            d_VB.t(),
+            None,
+            None,
+        )
+
+
+def apply_lora_qkv(self, X, inplace=True):
+    X = _maybe_fake_quantize_activations(X, self.q_proj)
+    QW, QW_quant, QA, QB, QS = get_lora_parameters(self.q_proj)
+    KW, KW_quant, KA, KB, KS = get_lora_parameters(self.k_proj)
+    VW, VW_quant, VA, VB, VS = get_lora_parameters(self.v_proj)
+    Q, K, V = LoRA_QKV.apply(
+        X,
+        QW,
+        QW_quant,
+        QA,
+        QB,
+        QS,
+        KW,
+        KW_quant,
+        KA,
+        KB,
+        KS,
+        VW,
+        VW_quant,
+        VA,
+        VB,
+        VS,
+        inplace,
+    )
+    return Q, K, V
+
+
+class LoRA_W(torch.autograd.Function):
+    @staticmethod
+    @torch_amp_custom_fwd
+    def forward(ctx, X: torch.Tensor, W, W_quant, A, B, S):
+        XW = matmul_lora(X, W, W_quant, A, B, S)
+        ctx.custom_saved_tensors = (W, W_quant, S)
+        ctx.save_for_backward(A, B, X)
+        return XW
+
+    @staticmethod
+    @torch_amp_custom_bwd
+    def backward(ctx, dY: torch.Tensor):
+        W, W_quant, S = ctx.custom_saved_tensors
+        A, B, X = ctx.saved_tensors
+
+        batch, seq_len, hd = X.shape
+        dY = dY.reshape(-1, dY.shape[-1])
+        X = X.reshape(-1, X.shape[-1])
+        dtype = X.dtype
+
+        A, B = A.to(dtype), B.to(dtype)
+        A, B = A.t(), B.t()
+
+        d_A = torch.empty_like(A)
+        d_B = torch.empty_like(B)
+        d_A.addmm_(X.t(), dY @ B.t(), alpha=S, beta=0)
+        d_B.addmm_(A.t() @ X.t(), dY, alpha=S, beta=0)
+
+        W = fast_dequantize(W.t(), W_quant)
+        dX = dY @ W.t()
+        del W
+        dX.addmm_(dY @ B.t(), A.t(), alpha=S)
+
+        return dX.view(batch, seq_len, hd), None, None, d_A.t(), d_B.t(), None
+
+
+def apply_lora_o(self, X):
+    X = _maybe_fake_quantize_activations(X, self.o_proj)
+    OW, OW_quant, OA, OB, OS = get_lora_parameters(self.o_proj)
+    O = LoRA_W.apply(X, OW, OW_quant, OA, OB, OS)
+    return O
+
+
+IDENTITY_DROPOUT = torch.nn.Identity
+
+
+@torch._disable_dynamo
+def fast_lora_forward(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+    raise NotImplementedError(
+        "Unsloth: Currently not supported yet - reshaping done incorrectly"
+    )
+    self._check_forward_args(x, *args, **kwargs)
+    adapter_names = kwargs.pop("adapter_names", None)
+
+    if self.disable_adapters:
+        if self.merged:
+            self.unmerge()
+        result = self.base_layer(x, *args, **kwargs)
+    elif adapter_names is not None:
+        result = self._mixed_batch_forward(
+            x, *args, adapter_names=adapter_names, **kwargs
+        )
+    elif self.merged:
+        result = self.base_layer(x, *args, **kwargs)
+    else:
+        if len(self.active_adapters) == 1:
+            active_adapter = self.active_adapters[0]
+            if active_adapter not in self.lora_A.keys():
+                return self.base_layer(x, *args, **kwargs)
+
+            dropout = self.lora_dropout[active_adapter]
+            if (
+                isinstance(dropout, IDENTITY_DROPOUT)
+                and not self.use_dora[active_adapter]
+            ):
+                lora_A = self.lora_A[active_adapter].weight
+                lora_B = self.lora_B[active_adapter].weight
+                scaling = self.scaling[active_adapter]
+                W = self.base_layer.weight
+                return LoRA_W.apply(x, W, QUANT_STATE(W), lora_A, lora_B, scaling)
+
+        result = self.base_layer(x, *args, **kwargs)
+        result = result.clone()
+
+        for active_adapter in self.active_adapters:
+            if active_adapter not in self.lora_A.keys():
+                continue
+            lora_A = self.lora_A[active_adapter]
+            lora_B = self.lora_B[active_adapter]
+            dropout = self.lora_dropout[active_adapter]
+            scaling = self.scaling[active_adapter]
+
+            requires_conversion = not torch.is_autocast_enabled()
+            if requires_conversion:
+                expected_dtype = result.dtype
+                x = x.to(lora_A.weight.dtype)
+
+            if not self.use_dora[active_adapter]:
+                result = result + lora_B(lora_A(dropout(x))) * scaling
+            else:
+                if isinstance(dropout, torch.nn.Identity) or not self.training:
+                    base_result = result
+                else:
+                    x = dropout(x)
+                    base_result = None
+
+                result = result + self.lora_magnitude_vector[active_adapter](
+                    x,
+                    lora_A=lora_A,
+                    lora_B=lora_B,
+                    scaling=scaling,
+                    base_layer=self.get_base_layer(),
+                    base_result=base_result,
+                )
+            if requires_conversion:
+                result = result.to(expected_dtype)
+
+    return result

--- a/unturtle/kernels/_fast_lora_utils.py
+++ b/unturtle/kernels/_fast_lora_utils.py
@@ -1,0 +1,336 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Vendored from unsloth/kernels/utils.py for issue #67.
+
+from __future__ import annotations
+
+import ctypes
+import importlib
+
+try:
+    import bitsandbytes as bnb
+except Exception as exc:  # noqa: BLE001
+    raise ImportError(
+        "unturtle.kernels.fast_lora requires bitsandbytes to be importable"
+    ) from exc
+
+import torch
+
+from ._fp8 import fp8_linear, weight_dequant
+from ._triton_utils import DEVICE_COUNT, torch_device_stream, torch_gpu_device
+
+
+def _version_tuple(version: str) -> tuple[int, ...]:
+    out: list[int] = []
+    for part in version.replace("+", ".").replace("-", ".").split("."):
+        digits = "".join(ch for ch in part if ch.isdigit())
+        if digits:
+            out.append(int(digits))
+        else:
+            break
+    return tuple(out)
+
+
+if _version_tuple(torch.__version__) < (2, 4, 0):
+    torch_amp_custom_fwd = torch.cuda.amp.custom_fwd
+    torch_amp_custom_bwd = torch.cuda.amp.custom_bwd
+else:
+    torch_amp_custom_fwd = torch.amp.custom_fwd(device_type="cuda")
+    torch_amp_custom_bwd = torch.amp.custom_bwd(device_type="cuda")
+
+
+HAS_CUDA_STREAM = _version_tuple(bnb.__version__) > (0, 43, 3)
+get_ptr = bnb.functional.get_ptr
+
+c_void_p = ctypes.c_void_p
+ctypes_c_int = ctypes.c_int
+ctypes_c_int32 = ctypes.c_int32
+cdequantize_blockwise_fp32 = bnb.functional.lib.cdequantize_blockwise_fp32
+cdequantize_blockwise_fp16_nf4 = bnb.functional.lib.cdequantize_blockwise_fp16_nf4
+cdequantize_blockwise_bf16_nf4 = bnb.functional.lib.cdequantize_blockwise_bf16_nf4
+cgemm_4bit_inference_naive_fp16 = bnb.functional.lib.cgemm_4bit_inference_naive_fp16
+cgemm_4bit_inference_naive_bf16 = bnb.functional.lib.cgemm_4bit_inference_naive_bf16
+
+torch_mm = torch.mm
+torch_mv = torch.mv
+torch_matmul = torch.matmul
+torch_empty = torch.empty
+torch_float32 = torch.float32
+torch_float16 = torch.float16
+torch_bfloat16 = torch.bfloat16
+
+if importlib.util.find_spec("torchao") is not None:
+    try:
+        from torchao.quantization import Float8Tensor
+    except Exception:
+        Float8Tensor = type(None)
+else:
+    Float8Tensor = type(None)
+
+
+def QUANT_STATE(W):
+    return getattr(W, "quant_state", None)
+
+
+def get_lora_parameters(proj):
+    base_layer = getattr(proj, "base_layer", proj)
+    W = base_layer.weight
+
+    if hasattr(base_layer, "weight_fake_quantizer"):
+        weight_fake_quantizer = getattr(base_layer, "weight_fake_quantizer", None)
+        if weight_fake_quantizer is not None:
+            W = weight_fake_quantizer(W)
+
+    W_quant = getattr(W, "quant_state", None)
+    if W_quant is None:
+        W_quant = getattr(base_layer, "weight_scale_inv", None)
+        if W_quant is None:
+            W_quant = getattr(base_layer, "weight_scale", None)
+
+    if getattr(base_layer, "quant_method", None) == "fp8":
+        W.block_size = getattr(base_layer, "block_size", [128, 128])
+        W_quant.block_size = W.block_size
+
+    if getattr(proj, "disable_adapters", True) or proj.merged:
+        return W, W_quant, None, None, None
+
+    adapter = getattr(proj, "active_adapters", None)
+    if adapter is None:
+        adapter = getattr(proj, "active_adapter", ("default"))
+    adapter = adapter[0]
+
+    lora_A_linear = proj.lora_A[adapter]
+    lora_B_linear = proj.lora_B[adapter]
+    A = lora_A_linear.weight
+    B = lora_B_linear.weight
+    if hasattr(lora_A_linear, "weight_fake_quantizer"):
+        lora_A_fake_quantizer = getattr(lora_A_linear, "weight_fake_quantizer", None)
+        if lora_A_fake_quantizer is not None:
+            A = lora_A_fake_quantizer(A)
+    if hasattr(lora_B_linear, "weight_fake_quantizer"):
+        lora_B_fake_quantizer = getattr(lora_B_linear, "weight_fake_quantizer", None)
+        if lora_B_fake_quantizer is not None:
+            B = lora_B_fake_quantizer(B)
+
+    return W, W_quant, A, B, proj.scaling[adapter]
+
+
+def get_lora_parameters_bias(proj):
+    base_layer = getattr(proj, "base_layer", proj)
+    W = base_layer.weight
+
+    if hasattr(base_layer, "weight_fake_quantizer"):
+        weight_fake_quantizer = getattr(base_layer, "weight_fake_quantizer", None)
+        if weight_fake_quantizer is not None:
+            W = weight_fake_quantizer(W)
+
+    W_quant = getattr(W, "quant_state", None)
+    if W_quant is None:
+        W_quant = getattr(base_layer, "weight_scale_inv", None)
+        if W_quant is None:
+            W_quant = getattr(base_layer, "weight_scale", None)
+
+    if getattr(base_layer, "quant_method", None) == "fp8":
+        W.block_size = getattr(base_layer, "block_size", [128, 128])
+        W_quant.block_size = W.block_size
+
+    if getattr(proj, "disable_adapters", True) or proj.merged:
+        return W, W_quant, None, None, None, base_layer.bias
+
+    adapter = getattr(proj, "active_adapters", None)
+    if adapter is None:
+        adapter = getattr(proj, "active_adapter", ("default"))
+    adapter = adapter[0]
+
+    lora_A_linear = proj.lora_A[adapter]
+    lora_B_linear = proj.lora_B[adapter]
+    A = lora_A_linear.weight
+    B = lora_B_linear.weight
+    if hasattr(lora_A_linear, "weight_fake_quantizer"):
+        lora_A_fake_quantizer = getattr(lora_A_linear, "weight_fake_quantizer", None)
+        if lora_A_fake_quantizer is not None:
+            A = lora_A_fake_quantizer(A)
+    if hasattr(lora_B_linear, "weight_fake_quantizer"):
+        lora_B_fake_quantizer = getattr(lora_B_linear, "weight_fake_quantizer", None)
+        if lora_B_fake_quantizer is not None:
+            B = lora_B_fake_quantizer(B)
+
+    return (
+        W,
+        W_quant,
+        A,
+        B,
+        proj.scaling[adapter],
+        base_layer.bias,
+    )
+
+
+def _maybe_fake_quantize_activations(
+    X: torch.Tensor, proj: torch.nn.Module
+) -> torch.Tensor:
+    base_layer = getattr(proj, "base_layer", proj)
+    activation_fake_quantizer = getattr(base_layer, "activation_fake_quantizer", None)
+    if activation_fake_quantizer is not None:
+        X = activation_fake_quantizer(X)
+    return X
+
+
+if DEVICE_COUNT > 0 and HAS_CUDA_STREAM:
+    _CUDA_STREAMS = {
+        (index := torch.cuda.device(i).idx): ctypes.c_void_p(
+            torch._C._cuda_getCurrentRawStream(index)
+        )
+        for i in range(DEVICE_COUNT)
+    }
+    CUDA_STREAMS = [None] * (max(_CUDA_STREAMS.keys()) + 1)
+    WEIGHT_BUFFERS = [None] * (max(_CUDA_STREAMS.keys()) + 1)
+    ABSMAX_BUFFERS = [None] * (max(_CUDA_STREAMS.keys()) + 1)
+    for k, v in _CUDA_STREAMS.items():
+        CUDA_STREAMS[k] = v
+    CUDA_STREAMS = tuple(CUDA_STREAMS)
+    del _CUDA_STREAMS
+else:
+    CUDA_STREAMS = ()
+    WEIGHT_BUFFERS = []
+    ABSMAX_BUFFERS = []
+
+
+@torch.inference_mode
+def fast_dequantize(W, quant_state=None, out=None, use_global_buffer=False):
+    if isinstance(W, Float8Tensor):
+        return W.dequantize()
+    if quant_state is None:
+        return W
+    if W.dtype == torch.float8_e4m3fn:
+        return weight_dequant(W, quant_state)
+
+    if type(quant_state) is not list:
+        absmax = quant_state.absmax
+        shape = quant_state.shape
+        dtype = quant_state.dtype
+        blocksize = quant_state.blocksize
+        offset = quant_state.offset
+        state2 = quant_state.state2
+        absmax2 = state2.absmax
+        code2 = state2.code
+        blocksize2 = state2.blocksize
+    else:
+        absmax, shape, dtype, blocksize, compressed_stats, _, _ = quant_state
+        offset, state2 = compressed_stats
+        absmax2, code2, blocksize2, _, _, _, _ = state2
+
+    device = W.device
+    device_index = device.index
+    CUDA_STREAM = CUDA_STREAMS[device_index]
+    n_elements_absmax = absmax.numel()
+
+    if use_global_buffer:
+        size = shape[0] * shape[1]
+        WEIGHT_BUFFER = WEIGHT_BUFFERS[device_index]
+        ABSMAX_BUFFER = ABSMAX_BUFFERS[device_index]
+        if WEIGHT_BUFFER is None or WEIGHT_BUFFER.dtype != dtype:
+            WEIGHT_BUFFERS[device_index] = WEIGHT_BUFFER = torch_empty(
+                size, dtype=dtype, device=device, requires_grad=False
+            )
+            ABSMAX_BUFFERS[device_index] = ABSMAX_BUFFER = torch_empty(
+                n_elements_absmax,
+                dtype=torch_float32,
+                device=device,
+                requires_grad=False,
+            )
+
+        if size > WEIGHT_BUFFER.numel():
+            WEIGHT_BUFFER.resize_(size)
+        if n_elements_absmax > ABSMAX_BUFFER.numel():
+            ABSMAX_BUFFER.resize_(n_elements_absmax)
+
+        out = WEIGHT_BUFFER[:size].view(shape)
+        out_absmax = ABSMAX_BUFFER[:n_elements_absmax]
+    else:
+        if out is None:
+            out = torch_empty(shape, dtype=dtype, device=device, requires_grad=False)
+        else:
+            assert out.shape == shape
+            assert out.dtype == dtype
+        out_absmax = torch_empty(
+            n_elements_absmax,
+            dtype=torch_float32,
+            device=device,
+            requires_grad=False,
+        )
+
+    ptr_out_absmax = get_ptr(out_absmax)
+    with torch_gpu_device(device):
+        cdequantize_blockwise_fp32(
+            get_ptr(code2),
+            get_ptr(absmax),
+            get_ptr(absmax2),
+            ptr_out_absmax,
+            ctypes_c_int(blocksize2),
+            ctypes_c_int(n_elements_absmax),
+            CUDA_STREAM,
+        )
+        out_absmax += offset
+
+        fx = (
+            cdequantize_blockwise_fp16_nf4
+            if dtype == torch_float16
+            else cdequantize_blockwise_bf16_nf4
+        )
+        fx(
+            get_ptr(None),
+            get_ptr(W),
+            ptr_out_absmax,
+            get_ptr(out),
+            ctypes_c_int(blocksize),
+            ctypes_c_int(out.numel()),
+            CUDA_STREAM,
+        )
+
+    is_transposed = W.shape[0] == 1
+    return out.t() if is_transposed else out
+
+
+def matmul_lora(X, W, W_quant, A, B, s, out=None):
+    dtype = X.dtype
+
+    if X.dim() == 3:
+        batch, seq_len, d = X.shape
+        X = X.view(-1, X.shape[-1])
+        reshape = True
+    else:
+        reshape = False
+
+    if isinstance(W, Float8Tensor):
+        assert W.ndim == 2
+        if W.block_size[0] == W.shape[0] and W.block_size[1] == 1:
+            W = W.dequantize()
+        else:
+            W = W.contiguous()
+        out = torch_matmul(X, W.t(), out=out)
+    elif W.dtype == torch.float8_e4m3fn:
+        out = fp8_linear(X, W, W_quant)
+    else:
+        W = fast_dequantize(W, W_quant, use_global_buffer=True)
+        out = torch_matmul(X, W.t(), out=out)
+    if W_quant is not None:
+        del W
+
+    if A is not None:
+        A, B = A.t(), B.t()
+        XA = torch_matmul(X, A.to(dtype))
+        out.addmm_(XA, B.to(dtype), alpha=s)
+
+    return out.view(batch, seq_len, -1) if reshape else out

--- a/unturtle/kernels/_fp8.py
+++ b/unturtle/kernels/_fp8.py
@@ -1,0 +1,513 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Vendored from unsloth/kernels/fp8.py for issue #67.
+
+from __future__ import annotations
+
+import os
+
+import torch
+import triton
+import triton.language as tl
+
+from ._triton_utils import torch_gpu_device
+
+try:
+    from transformers.integrations.finegrained_fp8 import FP8Linear
+except Exception:
+    FP8Linear = None
+
+try:
+    from transformers.integrations.fbgemm_fp8 import FbgemmFp8Linear
+except Exception:
+    FbgemmFp8Linear = None
+
+try:
+    from fbgemm_gpu.experimental.gemm.triton_gemm.fp8_gemm import (
+        triton_quantize_fp8_block,
+    )
+except Exception:
+    triton_quantize_fp8_block = None
+
+try:
+    from torchao.prototype.blockwise_fp8_inference.blockwise_quantization import (
+        blockwise_fp8_gemm as torchao_blockwise_gemm,
+    )
+except Exception:
+    torchao_blockwise_gemm = None
+
+
+torch_matmul = torch.matmul
+
+
+@triton.jit
+def weight_dequant_kernel(x_ptr, s_ptr, y_ptr, M, N, BLOCK_SIZE: tl.constexpr):
+    pid_m = tl.program_id(axis=0)
+    pid_n = tl.program_id(axis=1)
+    n = tl.cdiv(N, BLOCK_SIZE)
+    offs_m = pid_m * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    offs_n = pid_n * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    offs = offs_m[:, None] * N + offs_n[None, :]
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+    x = tl.load(x_ptr + offs, mask=mask).to(tl.float32)
+    s = tl.load(s_ptr + pid_m * n + pid_n)
+    y = x * s
+    tl.store(y_ptr + offs, y, mask=mask)
+
+
+def weight_dequant_block(
+    x: torch.Tensor, s: torch.Tensor, block_size: int = 128, dtype=torch.bfloat16
+) -> torch.Tensor:
+    if not x.is_contiguous():
+        x = x.contiguous()
+    if not s.is_contiguous():
+        s = s.contiguous()
+    assert x.dim() == 2 and s.dim() == 2
+    M, N = x.size()
+    y = torch.empty_like(x, dtype=dtype)
+    grid = lambda meta: (
+        triton.cdiv(M, meta["BLOCK_SIZE"]),
+        triton.cdiv(N, meta["BLOCK_SIZE"]),
+    )
+    weight_dequant_kernel[grid](x, s, y, M, N, BLOCK_SIZE=block_size)
+    return y
+
+
+def weight_dequant(x: torch.Tensor, s: torch.Tensor, dtype=torch.bfloat16):
+    if s.numel() == 1:
+        return x.to(dtype) * s.view(1, 1).to(dtype)
+    if s.ndim == 2 and s.shape[1] == 1:
+        if x.shape[0] == s.shape[0]:
+            y = x.to(dtype) * s.to(dtype)
+        elif x.shape[1] == s.shape[0]:
+            y = x.t().to(dtype) * s.to(dtype)
+            y = y.t()
+        else:
+            raise ValueError(f"Incompatible shapes {x.shape = }, {s.shape = }")
+        return y
+    return weight_dequant_block(x, s, dtype=dtype)
+
+
+@triton.jit
+def act_quant_kernel(x_ptr, y_ptr, s_ptr, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    x = tl.load(x_ptr + offs).to(tl.float32)
+    s = tl.max(tl.abs(x)) / 448.0
+    s = 1.0 if s == 0 else s
+    y = x / s
+    y = y.to(y_ptr.dtype.element_ty)
+    tl.store(y_ptr + offs, y)
+    tl.store(s_ptr + pid, s)
+
+
+def act_quant(
+    x: torch.Tensor, block_size: int = 128
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if not x.is_contiguous():
+        x = x.contiguous()
+    assert x.shape[-1] % block_size == 0
+    y = torch.empty_like(x, dtype=torch.float8_e4m3fn)
+    s = x.new_empty(*x.size()[:-1], x.size(-1) // block_size, dtype=torch.float32)
+
+    def grid(meta):
+        return (triton.cdiv(x.numel(), meta["BLOCK_SIZE"]),)
+
+    act_quant_kernel[grid](x, y, s, BLOCK_SIZE=block_size)
+    return y, s
+
+
+@triton.jit
+def _w8a8_block_fp8_matmul(
+    A,
+    B,
+    C,
+    As,
+    Bs,
+    M,
+    N,
+    K,
+    group_n,
+    group_k,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    stride_As_m,
+    stride_As_k,
+    stride_Bs_k,
+    stride_Bs_n,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + (pid % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+    offs_am = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = A + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
+    b_ptrs = B + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+
+    As_ptrs = As + offs_am * stride_As_m
+    offs_bsn = offs_bn // group_n
+    Bs_ptrs = Bs + offs_bsn * stride_Bs_n
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+
+        k_start = k * BLOCK_SIZE_K
+        offs_ks = k_start // group_k
+        a_s = tl.load(As_ptrs + offs_ks * stride_As_k)
+        b_s = tl.load(Bs_ptrs + offs_ks * stride_Bs_k)
+
+        accumulator += tl.dot(a, b) * a_s[:, None] * b_s[None, :]
+        a_ptrs += BLOCK_SIZE_K * stride_ak
+        b_ptrs += BLOCK_SIZE_K * stride_bk
+
+    if C.dtype.element_ty == tl.bfloat16:
+        c = accumulator.to(tl.bfloat16)
+    elif C.dtype.element_ty == tl.float16:
+        c = accumulator.to(tl.float16)
+    else:
+        c = accumulator.to(tl.float32)
+
+    offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = C + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+    tl.store(c_ptrs, c, mask=c_mask)
+
+
+def w8a8_block_fp8_matmul_triton(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    As: torch.Tensor,
+    Bs: torch.Tensor,
+    block_size: list[int],
+    output_dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    if block_size is None:
+        block_n, block_k = 128, 128
+    else:
+        assert len(block_size) == 2
+        block_n, block_k = block_size[0], block_size[1]
+
+    N, K = B.shape
+    assert A.shape[-1] == B.shape[-1]
+    assert A.shape[:-1] == As.shape[:-1] and A.is_contiguous()
+    assert triton.cdiv(A.shape[-1], block_k) == As.shape[-1]
+    assert B.ndim == 2 and B.is_contiguous() and Bs.ndim == 2
+    assert triton.cdiv(N, block_n) == Bs.shape[0]
+    assert triton.cdiv(K, block_k) == Bs.shape[1]
+
+    M = A.numel() // A.shape[-1]
+    C_shape = A.shape[:-1] + (N,)
+    C = A.new_empty(C_shape, dtype=output_dtype)
+
+    BLOCK_SIZE_M = 128
+    if M < BLOCK_SIZE_M:
+        BLOCK_SIZE_M = max(triton.next_power_of_2(M), 16)
+    BLOCK_SIZE_K, BLOCK_SIZE_N = block_k, block_n
+
+    def grid(meta):
+        return (
+            triton.cdiv(M, meta["BLOCK_SIZE_M"]) * triton.cdiv(N, meta["BLOCK_SIZE_N"]),
+        )
+
+    _w8a8_block_fp8_matmul[grid](
+        A,
+        B,
+        C,
+        As,
+        Bs,
+        M,
+        N,
+        K,
+        block_n,
+        block_k,
+        A.stride(-2),
+        A.stride(-1),
+        B.stride(1),
+        B.stride(0),
+        C.stride(-2),
+        C.stride(-1),
+        As.stride(-2),
+        As.stride(-1),
+        Bs.stride(1),
+        Bs.stride(0),
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+    )
+    return C
+
+
+def torchao_block_matmul(
+    act_q: torch.Tensor,
+    weight_q: torch.Tensor,
+    act_scale: torch.Tensor,
+    weight_scale: torch.Tensor,
+    block_size: tuple[int, int],
+    output_dtype: torch.dtype = torch.bfloat16,
+):
+    out = torchao_blockwise_gemm(
+        act_q.contiguous(),
+        act_scale.contiguous(),
+        weight_q.contiguous(),
+        weight_scale.contiguous(),
+        block_size=block_size[1],
+    )
+    return out.to(output_dtype)
+
+
+fp8_block_matmul = (
+    torchao_block_matmul if torchao_blockwise_gemm is not None else w8a8_block_fp8_matmul_triton
+)
+
+
+class FP8BlockQuantLinear(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, X, weight, weight_scale):
+        m, n = weight.shape
+        original_weight_scale = weight_scale
+
+        if weight_scale.numel() == 1:
+            block_size = [128, 128]
+            num_blocks_m = triton.cdiv(m, block_size[0])
+            num_blocks_n = triton.cdiv(n, block_size[1])
+            weight_scale = weight_scale.expand(num_blocks_m, num_blocks_n).contiguous()
+        else:
+            p, q = weight_scale.shape
+            block_size = getattr(weight, "block_size", None) or getattr(
+                weight_scale, "block_size", [128, 128]
+            )
+            assert block_size is not None, "block_size is not set"
+            if triton.cdiv(m, block_size[0]) != p or triton.cdiv(n, block_size[1]) != q:
+                if triton.cdiv(m, block_size[0]) == q and triton.cdiv(n, block_size[1]) == p:
+                    weight_scale = weight_scale.T
+                    original_weight_scale = weight_scale
+                else:
+                    raise ValueError(
+                        f"Weight shape {weight.shape} and scales shape {weight_scale.shape} is not compatible with block size {block_size}"
+                    )
+
+        if not weight.is_contiguous():
+            weight = weight.contiguous()
+
+        qinput, scale = act_quant(X, block_size[1])
+        output = fp8_block_matmul(
+            qinput,
+            weight,
+            scale,
+            weight_scale,
+            block_size,
+            output_dtype=X.dtype,
+        )
+        ctx.weight = weight
+        ctx.weight_scale = original_weight_scale
+        return output.to(X.dtype)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        W_deq = weight_dequant(ctx.weight, ctx.weight_scale)
+        grad_X = torch_matmul(grad_output, W_deq)
+        del W_deq
+        return grad_X, None, None
+
+
+@torch.compiler.disable
+def fp8_torch_block_quant_forward(X, weight, weight_scale):
+    return FP8BlockQuantLinear.apply(X, weight, weight_scale)
+
+
+class FbgemmFp8Linear_matmul(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, weight, weight_scale, bias=None):
+        if weight.shape[0] == weight_scale.shape[0] and (
+            weight.shape[0] % 8 == 0 and weight.shape[1] % 8 == 0
+        ):
+            output_shape = (*x.shape[:-1], -1)
+            x_quantized, x_scale = torch.ops.fbgemm.quantize_fp8_per_row(
+                x.view(-1, x.shape[-1]).contiguous(),
+                scale_ub=getattr(weight, "input_scale_ub", None),
+            )
+            weight_scale_float32 = weight_scale.to(torch.float32)
+
+            if not weight.is_contiguous():
+                weight = weight.contiguous()
+            if not weight_scale.is_contiguous():
+                weight_scale = weight_scale.contiguous()
+
+            output = torch.ops.fbgemm.f8f8bf16_rowwise(
+                x_quantized, weight, x_scale, weight_scale_float32, use_fast_accum=True
+            )
+            output = output + bias if bias is not None else output
+            output = output.to(x.device, x.dtype)
+            output = output.reshape(output_shape)
+            del x_quantized, x_scale
+        elif (
+            weight.shape[0] != weight_scale.shape[0]
+            and weight.shape[1] == weight_scale.shape[0]
+        ) or (weight.shape[0] // 8 != 0 or weight.shape[1] // 8 != 0):
+            W_deq = weight_dequant(weight, weight_scale).T
+            output = torch_matmul(x, W_deq)
+            del W_deq
+        else:
+            raise ValueError(
+                f"Shapes are incompatible {weight.shape = }, {weight_scale.shape = }, {x.shape = }"
+            )
+
+        ctx.weight = weight
+        ctx.weight_scale = weight_scale
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        W_deq = weight_dequant(ctx.weight, ctx.weight_scale)
+        grad_X = torch_matmul(grad_output, W_deq)
+        del W_deq
+        return grad_X, None, None, None, None
+
+
+@torch.compiler.disable
+def fbgemm_fp8_linear(X, weight, weight_scale, bias=None):
+    return FbgemmFp8Linear_matmul.apply(X, weight, weight_scale, bias)
+
+
+class FP8_fbgemm_block_linear(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, X, weight, weight_scale, bias=None):
+        orig_shape = X.shape
+        X = X.view(-1, X.shape[-1])
+
+        bs_n, bs_k = getattr(weight, "block_size", None) or getattr(
+            weight_scale, "block_size", [128, 128]
+        )
+        bs_m = bs_n
+
+        m, n = weight.shape
+        p, q = weight_scale.shape
+
+        if triton.cdiv(m, bs_n) != p or triton.cdiv(n, bs_k) != q:
+            if triton.cdiv(m, bs_n) == q and triton.cdiv(n, bs_k) == p:
+                weight_scale = weight_scale.T
+            else:
+                raise ValueError(
+                    f"Weight shape {weight.shape} and scales shape {weight_scale.shape} is not compatible with block size {bs_n, bs_k}"
+                )
+
+        xq, xs = triton_quantize_fp8_block(X, bs_m, bs_n, None)
+        output = torch.ops.fbgemm.f8f8bf16_blockwise(
+            xq, weight.contiguous(), xs, weight_scale.contiguous(), bs_m, bs_n, bs_k
+        )
+        output = output + bias if bias is not None else output
+        output = output.view(*orig_shape[:-1], -1)
+
+        del xq
+        del xs
+
+        ctx.weight = weight
+        ctx.weight_scale = weight_scale
+        ctx.block_size = [bs_m, bs_n, bs_k]
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        W_deq = weight_dequant(ctx.weight, ctx.weight_scale)
+        grad_X = torch_matmul(grad_output, W_deq)
+        del W_deq
+        return grad_X, None, None, None, None
+
+
+@torch.compiler.disable
+def fp8_fbgemm_block_linear(X, weight, weight_scale, bias=None):
+    return FP8_fbgemm_block_linear.apply(X, weight, weight_scale, bias)
+
+
+def test_has_fbgemm():
+    M, N, K = 128, 128, 128
+    xq = torch.ones(M, K, dtype=torch.float8_e4m3fn, device="cuda")
+    wq = xq
+    M, K = xq.shape
+    N, _ = wq.shape
+    block_scale = torch.ones(M // 128, K // 128, dtype=torch.float32, device="cuda")
+    has_fbgemm = False
+    try:
+        out = torch.ops.fbgemm.f8f8bf16_blockwise(xq, wq, block_scale, block_scale)
+        assert torch.unique(out).item() == 128
+        has_fbgemm = True
+        del out
+    except Exception:
+        has_fbgemm = False
+    del block_scale, xq
+    torch.cuda.empty_cache()
+    return has_fbgemm
+
+
+fp8_block_quant_linear = fp8_torch_block_quant_forward
+if "UNSLOTH_HAS_FBGEMM" not in os.environ:
+    os.environ["UNSLOTH_HAS_FBGEMM"] = "0"
+try:
+    import fbgemm_gpu
+
+    version = tuple(int(x) for x in fbgemm_gpu.__version__.split(".")[:3])
+    if version >= (1, 4, 0):
+        _has_fbgemm = test_has_fbgemm()
+        if _has_fbgemm:
+            os.environ["UNSLOTH_HAS_FBGEMM"] = "1"
+            fp8_block_quant_linear = fp8_fbgemm_block_linear
+        else:
+            os.environ["UNSLOTH_HAS_FBGEMM"] = "0"
+except Exception:
+    pass
+
+
+@torch.compiler.disable
+def fp8_linear(X, weight, weight_scale, bias=None):
+    if weight_scale.numel() == 1 or (
+        weight_scale.ndim == 2 and weight_scale.shape[1] > 1
+    ):
+        out = fp8_block_quant_linear(X, weight, weight_scale)
+    else:
+        out = fbgemm_fp8_linear(X, weight, weight_scale, bias)
+    return out
+
+
+def module_forward_patch(forward_function, scale_attr="weight_scale"):
+    def patched_forward(self, X):
+        return forward_function(X, self.weight, getattr(self, scale_attr))
+
+    return patched_forward
+
+
+if FbgemmFp8Linear is not None:
+    FbgemmFp8Linear.forward = module_forward_patch(fbgemm_fp8_linear, "weight_scale")
+if FP8Linear is not None:
+    FP8Linear.forward = module_forward_patch(fp8_block_quant_linear, "weight_scale_inv")

--- a/unturtle/kernels/_geglu.py
+++ b/unturtle/kernels/_geglu.py
@@ -1,0 +1,241 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Vendored from unsloth/kernels/geglu.py for issue #67.
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from ._triton_utils import torch_gpu_device, triton_tanh
+
+NUM_INT32_ELEMENTS = 2**31
+SAFE_INT32_BUFFER_MULTIPLIER = 4
+BLOCK_SIZE = 1024
+INT32_SAFETY_BUFFER = NUM_INT32_ELEMENTS - BLOCK_SIZE * SAFE_INT32_BUFFER_MULTIPLIER
+
+
+@triton.jit
+def _exact_forward_kernel(
+    e,
+    g,
+    h,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+    LONG_INDEXING: tl.constexpr,
+):
+    block_idx = tl.program_id(0)
+    if LONG_INDEXING:
+        offsets = block_idx.to(tl.int64) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE).to(
+            tl.int64
+        )
+        n_elements = tl.cast(n_elements, tl.int64)
+    else:
+        offsets = block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    e_row = tl.load(e + offsets, mask=mask, other=0).to(tl.float32)
+    g_row = tl.load(g + offsets, mask=mask, other=0)
+
+    f_row = 0.5 * e_row * (tl.math.erf(tl.math.rsqrt(2.0) * e_row) + 1.0)
+    f_row = f_row.to(g_row.dtype)
+    h_row = f_row * g_row
+    tl.store(h + offsets, h_row, mask=mask)
+
+
+def geglu_exact_forward_kernel(gate, up):
+    batch, seq_len, hd = gate.shape
+    n_elements = gate.numel()
+    device = gate.device
+    out = torch.empty((batch, seq_len, hd), dtype=gate.dtype, device=device)
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    with torch_gpu_device(device):
+        _exact_forward_kernel[grid](
+            gate,
+            up,
+            out,
+            n_elements,
+            BLOCK_SIZE=BLOCK_SIZE,
+            LONG_INDEXING=0 if n_elements <= INT32_SAFETY_BUFFER else 1,
+        )
+    return out
+
+
+@triton.jit
+def _exact_backward_kernel(
+    DW,
+    e,
+    g,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+    LONG_INDEXING: tl.constexpr,
+):
+    block_idx = tl.program_id(0)
+    if LONG_INDEXING:
+        offsets = block_idx.to(tl.int64) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE).to(
+            tl.int64
+        )
+        n_elements = tl.cast(n_elements, tl.int64)
+    else:
+        offsets = block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    DW_row = tl.load(DW + offsets, mask=mask, other=0)
+    e_row = tl.load(e + offsets, mask=mask, other=0).to(tl.float32)
+    g_row = tl.load(g + offsets, mask=mask, other=0)
+
+    f_partial_row = 0.5 * (tl.math.erf(tl.math.rsqrt(2.0) * e_row) + 1.0)
+    f_row = f_partial_row * e_row
+
+    f_row = f_row.to(DW_row.dtype)
+    h_row = f_row * g_row
+    df_row = DW_row * f_row
+    dg_row = DW_row * g_row
+
+    t = 0.3989422804014327
+    df_de = f_partial_row + t * e_row * tl.exp(-0.5 * e_row * e_row)
+
+    de_row = dg_row.to(tl.float32) * df_de
+    de_row = de_row.to(DW_row.dtype)
+
+    tl.store(DW + offsets, h_row, mask=mask)
+    tl.store(e + offsets, df_row, mask=mask)
+    tl.store(g + offsets, de_row, mask=mask)
+
+
+def geglu_exact_backward_kernel(DW, e, g):
+    batch_seq_len, hd = e.shape
+    n_elements = e.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    with torch_gpu_device(e.device):
+        _exact_backward_kernel[grid](
+            DW,
+            e,
+            g,
+            n_elements,
+            BLOCK_SIZE=BLOCK_SIZE,
+            LONG_INDEXING=0 if n_elements <= INT32_SAFETY_BUFFER else 1,
+        )
+    return DW, e, g
+
+
+@triton.jit
+def _approx_forward_kernel(
+    e,
+    g,
+    h,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+    LONG_INDEXING: tl.constexpr,
+):
+    block_idx = tl.program_id(0)
+    if LONG_INDEXING:
+        offsets = block_idx.to(tl.int64) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE).to(
+            tl.int64
+        )
+        n_elements = tl.cast(n_elements, tl.int64)
+    else:
+        offsets = block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    s = 0.7978845608028654
+
+    e_row = tl.load(e + offsets, mask=mask, other=0).to(tl.float32)
+    g_row = tl.load(g + offsets, mask=mask, other=0)
+
+    f_row = 0.5 * e_row * (triton_tanh(s * e_row * (1.0 + 0.044715 * e_row * e_row)) + 1.0)
+    f_row = f_row.to(g_row.dtype)
+    h_row = f_row * g_row
+    tl.store(h + offsets, h_row, mask=mask)
+
+
+def geglu_approx_forward_kernel(gate, up):
+    batch, seq_len, hd = gate.shape
+    n_elements = gate.numel()
+    device = gate.device
+    out = torch.empty((batch, seq_len, hd), dtype=gate.dtype, device=device)
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    with torch_gpu_device(device):
+        _approx_forward_kernel[grid](
+            gate,
+            up,
+            out,
+            n_elements,
+            BLOCK_SIZE=BLOCK_SIZE,
+            LONG_INDEXING=0 if n_elements <= INT32_SAFETY_BUFFER else 1,
+        )
+    return out
+
+
+@triton.jit
+def _approx_backward_kernel(
+    DW,
+    e,
+    g,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+    LONG_INDEXING: tl.constexpr,
+):
+    block_idx = tl.program_id(0)
+    if LONG_INDEXING:
+        offsets = block_idx.to(tl.int64) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE).to(
+            tl.int64
+        )
+        n_elements = tl.cast(n_elements, tl.int64)
+    else:
+        offsets = block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    DW_row = tl.load(DW + offsets, mask=mask, other=0)
+    e_row = tl.load(e + offsets, mask=mask, other=0).to(tl.float32)
+    g_row = tl.load(g + offsets, mask=mask, other=0)
+
+    s = 0.7978845608028654
+    a = s * e_row
+    b = a * 0.044715 * e_row * e_row
+    T = 1.0 + triton_tanh(a + b)
+    T2 = 0.5 * T
+    Q2 = -T2 * (T - 2.0) * (a + 3.0 * b)
+    df_de = T2 + Q2
+
+    f_row = T2 * e_row
+    f_row = f_row.to(DW_row.dtype)
+    h_row = f_row * g_row
+    df_row = DW_row * f_row
+    dg_row = DW_row * g_row
+
+    de_row = dg_row.to(tl.float32) * df_de
+    de_row = de_row.to(DW_row.dtype)
+
+    tl.store(DW + offsets, h_row, mask=mask)
+    tl.store(e + offsets, df_row, mask=mask)
+    tl.store(g + offsets, de_row, mask=mask)
+
+
+def geglu_approx_backward_kernel(DW, e, g):
+    batch_seq_len, hd = e.shape
+    n_elements = e.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    with torch_gpu_device(e.device):
+        _approx_backward_kernel[grid](
+            DW,
+            e,
+            g,
+            n_elements,
+            BLOCK_SIZE=BLOCK_SIZE,
+            LONG_INDEXING=0 if n_elements <= INT32_SAFETY_BUFFER else 1,
+        )
+    return DW, e, g

--- a/unturtle/kernels/_swiglu.py
+++ b/unturtle/kernels/_swiglu.py
@@ -1,0 +1,126 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Vendored from unsloth/kernels/swiglu.py for issue #67.
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from ._triton_utils import torch_gpu_device
+
+NUM_INT32_ELEMENTS = 2**31
+SAFE_INT32_BUFFER_MULTIPLIER = 4
+BLOCK_SIZE = 1024
+INT32_SAFETY_BUFFER = NUM_INT32_ELEMENTS - BLOCK_SIZE * SAFE_INT32_BUFFER_MULTIPLIER
+
+
+@triton.jit
+def _fg_kernel(
+    e,
+    g,
+    h,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+    LONG_INDEXING: tl.constexpr,
+):
+    block_idx = tl.program_id(0)
+    if LONG_INDEXING:
+        offsets = block_idx.to(tl.int64) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE).to(
+            tl.int64
+        )
+        n_elements = tl.cast(n_elements, tl.int64)
+    else:
+        offsets = block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    e_row = tl.load(e + offsets, mask=mask, other=0).to(tl.float32)
+    g_row = tl.load(g + offsets, mask=mask, other=0)
+
+    f_row = e_row * tl.sigmoid(e_row)
+    f_row = f_row.to(g_row.dtype)
+    h_row = f_row * g_row
+    tl.store(h + offsets, h_row, mask=mask)
+
+
+def swiglu_fg_kernel(e, g):
+    batch, seq_len, hd = e.shape
+    n_elements = e.numel()
+    h = torch.empty((batch, seq_len, hd), dtype=e.dtype, device=e.device)
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    with torch_gpu_device(e.device):
+        _fg_kernel[grid](
+            e,
+            g,
+            h,
+            n_elements,
+            BLOCK_SIZE=BLOCK_SIZE,
+            LONG_INDEXING=0 if n_elements <= INT32_SAFETY_BUFFER else 1,
+        )
+    return h
+
+
+@triton.jit
+def _DWf_DW_dfg_kernel(
+    DW,
+    e,
+    g,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+    LONG_INDEXING: tl.constexpr,
+):
+    block_idx = tl.program_id(0)
+    if LONG_INDEXING:
+        offsets = block_idx.to(tl.int64) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE).to(
+            tl.int64
+        )
+        n_elements = tl.cast(n_elements, tl.int64)
+    else:
+        offsets = block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    DW_row = tl.load(DW + offsets, mask=mask, other=0)
+    e_row = tl.load(e + offsets, mask=mask, other=0).to(tl.float32)
+    g_row = tl.load(g + offsets, mask=mask, other=0)
+
+    se_row = tl.sigmoid(e_row)
+    f_row = se_row * e_row
+    f_row = f_row.to(DW_row.dtype)
+    h_row = f_row * g_row
+    df_row = DW_row * f_row
+    dg_row = DW_row * g_row
+    de_row = dg_row.to(tl.float32) * se_row * (1.0 + e_row * (1.0 - se_row))
+    de_row = de_row.to(DW_row.dtype)
+
+    tl.store(DW + offsets, h_row, mask=mask)
+    tl.store(e + offsets, df_row, mask=mask)
+    tl.store(g + offsets, de_row, mask=mask)
+
+
+def swiglu_DWf_DW_dfg_kernel(DW, e, g):
+    batch_seq_len, hd = e.shape
+    n_elements = e.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    with torch_gpu_device(e.device):
+        _DWf_DW_dfg_kernel[grid](
+            DW,
+            e,
+            g,
+            n_elements,
+            BLOCK_SIZE=BLOCK_SIZE,
+            LONG_INDEXING=0 if n_elements <= INT32_SAFETY_BUFFER else 1,
+        )
+    return DW, e, g

--- a/unturtle/kernels/_triton_utils.py
+++ b/unturtle/kernels/_triton_utils.py
@@ -1,0 +1,130 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import functools
+from contextlib import nullcontext
+
+import torch
+import triton
+import triton.language as tl
+
+MAX_FUSED_SIZE: int = 65536
+
+
+def _version_tuple(version: str) -> tuple[int, ...]:
+    out: list[int] = []
+    for part in version.replace("+", ".").replace("-", ".").split("."):
+        digits = "".join(ch for ch in part if ch.isdigit())
+        if digits:
+            out.append(int(digits))
+        else:
+            break
+    return tuple(out)
+
+
+@functools.lru_cache(1)
+def is_hip() -> bool:
+    return bool(getattr(getattr(torch, "version", None), "hip", None))
+
+
+@functools.lru_cache(1)
+def _device_type() -> str:
+    if hasattr(torch, "cuda") and torch.cuda.is_available():
+        return "hip" if is_hip() else "cuda"
+    if hasattr(torch, "xpu") and torch.xpu.is_available():
+        return "xpu"
+    return "cpu"
+
+
+@functools.lru_cache(1)
+def _device_count() -> int:
+    device_type = _device_type()
+    if device_type in ("cuda", "hip"):
+        return torch.cuda.device_count()
+    if device_type == "xpu":
+        return torch.xpu.device_count()
+    return 0
+
+
+DEVICE_COUNT: int = _device_count()
+_DEVICE_TYPE = _device_type()
+_DEVICE_TYPE_TORCH = "cuda" if _DEVICE_TYPE == "hip" else _DEVICE_TYPE
+
+if _DEVICE_TYPE == "xpu":
+    torch_device_stream = torch.xpu.current_stream
+elif _DEVICE_TYPE in ("cuda", "hip"):
+    torch_device_stream = torch.cuda.current_stream
+else:
+
+    def torch_device_stream(device):
+        raise RuntimeError("Triton stream access requires CUDA, HIP, or XPU.")
+
+if DEVICE_COUNT > 1:
+    if _DEVICE_TYPE in ("cuda", "hip"):
+        torch_gpu_device = torch.cuda.device
+    elif _DEVICE_TYPE == "xpu":
+        torch_gpu_device = torch.xpu.device
+    else:
+
+        def torch_gpu_device(device):
+            return nullcontext()
+else:
+
+    def torch_gpu_device(device):
+        return nullcontext()
+
+
+if _version_tuple(triton.__version__) >= (3, 0, 0):
+    if _DEVICE_TYPE == "xpu":
+        triton_tanh = tl.extra.intel.libdevice.tanh
+    else:
+        from triton.language.extra import libdevice
+
+        triton_tanh = libdevice.tanh
+    triton_cast = tl.cast
+else:
+    triton_tanh = tl.math.tanh
+
+    @triton.jit
+    def triton_cast(x, dtype):
+        return x.to(dtype)
+
+
+@functools.lru_cache(1)
+def is_cdna() -> bool:
+    return is_hip() and triton.runtime.driver.active.get_current_target().arch in (
+        "gfx940",
+        "gfx941",
+        "gfx942",
+        "gfx950",
+    )
+
+
+def calculate_settings(n: int) -> tuple[int, int]:
+    block_size: int = triton.next_power_of_2(n)
+    if block_size > MAX_FUSED_SIZE:
+        raise RuntimeError(
+            f"Cannot launch Triton kernel since n = {n} exceeds "
+            f"the maximum CUDA blocksize = {MAX_FUSED_SIZE}."
+        )
+    num_warps: int = 4
+    if block_size >= 32768:
+        num_warps = 32
+    elif block_size >= 8192:
+        num_warps = 16
+    elif block_size >= 2048:
+        num_warps = 8
+    return block_size, num_warps

--- a/unturtle/kernels/cross_entropy_loss.py
+++ b/unturtle/kernels/cross_entropy_loss.py
@@ -1,0 +1,307 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Vendored from unsloth/kernels/cross_entropy_loss.py for issue #67.
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from ._triton_utils import MAX_FUSED_SIZE, calculate_settings, is_cdna, torch_gpu_device, triton_cast, triton_tanh
+
+
+def _cross_entropy_forward(
+    logits_ptr,
+    logits_row_stride,
+    loss_ptr,
+    logsumexp_ptr,
+    labels_ptr,
+    VOCAB_SIZE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    DO_SOFTCAPPING: tl.constexpr,
+    SOFTCAP: tl.constexpr,
+    DO_LOGIT_SCALING: tl.constexpr,
+    LOGIT_SCALE: tl.constexpr,
+):
+    row_idx = tl.program_id(0)
+    logits_ptr += row_idx * triton_cast(logits_row_stride, tl.int64)
+    loss_ptr += row_idx
+    logsumexp_ptr += row_idx
+    labels_ptr += row_idx
+
+    col_offsets = tl.arange(0, BLOCK_SIZE)
+    mask = col_offsets < VOCAB_SIZE
+
+    label_idx = tl.load(labels_ptr).to(tl.int32)
+    logits = tl.load(logits_ptr + col_offsets, mask=mask, other=-float("inf")).to(tl.float32)
+
+    if DO_LOGIT_SCALING:
+        logits = LOGIT_SCALE * logits
+    if DO_SOFTCAPPING:
+        logits = SOFTCAP * triton_tanh(logits / SOFTCAP)
+
+    c = tl.max(logits, 0)
+    logsumexp = c + tl.log(tl.sum(tl.exp(logits - c), 0))
+
+    if label_idx != -100:
+        x = tl.load(logits_ptr + label_idx).to(tl.float32)
+        if DO_LOGIT_SCALING:
+            x = LOGIT_SCALE * x
+        if DO_SOFTCAPPING:
+            x = SOFTCAP * triton_tanh(x / SOFTCAP)
+        loss = logsumexp - x
+    else:
+        loss = 0.0
+    tl.store(logsumexp_ptr, logsumexp)
+    tl.store(loss_ptr, loss)
+
+
+_cross_entropy_forward = triton.jit(_cross_entropy_forward)
+_cross_entropy_forward = triton.heuristics(
+    {
+        "DO_SOFTCAPPING": lambda args: bool(args["DO_SOFTCAPPING"]),
+        "DO_LOGIT_SCALING": lambda args: bool(args["DO_LOGIT_SCALING"]),
+    }
+)(_cross_entropy_forward)
+
+
+def _chunked_cross_entropy_forward(
+    logits_ptr,
+    logits_row_stride: tl.constexpr,
+    loss_ptr,
+    logsumexp_ptr,
+    labels_ptr,
+    VOCAB_SIZE: tl.constexpr,
+    N_CHUNKS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    DO_SOFTCAPPING: tl.constexpr,
+    SOFTCAP: tl.constexpr,
+    DO_LOGIT_SCALING: tl.constexpr,
+    LOGIT_SCALE: tl.constexpr,
+):
+    row_idx = tl.program_id(0)
+    chunk_idx = tl.program_id(1)
+    logits_ptr += row_idx * triton_cast(logits_row_stride, tl.int64)
+    loss_ptr += row_idx
+    logsumexp_ptr += row_idx * N_CHUNKS + chunk_idx
+    labels_ptr += row_idx
+
+    col_offsets = chunk_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = col_offsets < VOCAB_SIZE
+
+    label_idx = tl.load(labels_ptr).to(tl.int32)
+    logits = tl.load(logits_ptr + col_offsets, mask=mask, other=-float("inf")).to(tl.float32)
+
+    if DO_LOGIT_SCALING:
+        logits = LOGIT_SCALE * logits
+    if DO_SOFTCAPPING:
+        logits = SOFTCAP * triton_tanh(logits / SOFTCAP)
+
+    c = tl.max(logits, 0)
+    logsumexp = c + tl.log(tl.sum(tl.exp(logits - c), 0))
+
+    if chunk_idx == 0:
+        if label_idx != -100:
+            x = tl.load(logits_ptr + label_idx).to(tl.float32)
+            if DO_LOGIT_SCALING:
+                x = LOGIT_SCALE * x
+            if DO_SOFTCAPPING:
+                x = SOFTCAP * triton_tanh(x / SOFTCAP)
+            loss = -1.0 * x
+        else:
+            loss = 0.0
+        tl.store(loss_ptr, loss)
+    tl.store(logsumexp_ptr, logsumexp)
+
+
+_chunked_cross_entropy_forward = triton.jit(_chunked_cross_entropy_forward)
+_chunked_cross_entropy_forward = triton.heuristics(
+    {
+        "DO_SOFTCAPPING": lambda args: bool(args["DO_SOFTCAPPING"]),
+        "DO_LOGIT_SCALING": lambda args: bool(args["DO_LOGIT_SCALING"]),
+    }
+)(_chunked_cross_entropy_forward)
+
+
+def _cross_entropy_backward(
+    logits_ptr,
+    logits_row_stride: tl.constexpr,
+    dloss_ptr,
+    dloss_row_stride: tl.constexpr,
+    logsumexp_ptr,
+    labels_ptr,
+    VOCAB_SIZE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    DO_SOFTCAPPING: tl.constexpr,
+    SOFTCAP: tl.constexpr,
+    DO_LOGIT_SCALING: tl.constexpr,
+    LOGIT_SCALE: tl.constexpr,
+):
+    row_idx = tl.program_id(0)
+    block_idx = tl.program_id(1)
+
+    logits_ptr += row_idx * triton_cast(logits_row_stride, tl.int64)
+    dloss_ptr += row_idx * dloss_row_stride
+    col_offsets = block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = col_offsets < VOCAB_SIZE
+    label_idx = tl.load(labels_ptr + row_idx).to(tl.int32)
+
+    if label_idx != -100:
+        dloss = tl.load(dloss_ptr)
+    else:
+        dloss = 0.0
+
+    x = tl.load(logits_ptr + col_offsets, mask=mask, other=-float("inf")).to(tl.float32)
+
+    if DO_LOGIT_SCALING:
+        x = x * LOGIT_SCALE
+
+    partial = x
+    if DO_SOFTCAPPING:
+        partial = triton_tanh(x / SOFTCAP)
+        x = SOFTCAP * partial
+
+    logsumexp = tl.load(logsumexp_ptr + row_idx)
+    y = tl.exp(x - logsumexp)
+    y = tl.where(col_offsets == label_idx, y - 1.0, y)
+
+    if DO_LOGIT_SCALING:
+        y = y * LOGIT_SCALE
+
+    if DO_SOFTCAPPING:
+        y = y * (1.0 - partial * partial)
+
+    tl.store(logits_ptr + col_offsets, dloss * y, mask=mask)
+
+
+_cross_entropy_backward = triton.jit(_cross_entropy_backward)
+_cross_entropy_backward = triton.heuristics(
+    {
+        "DO_SOFTCAPPING": lambda args: bool(args["DO_SOFTCAPPING"]),
+        "DO_LOGIT_SCALING": lambda args: bool(args["DO_LOGIT_SCALING"]),
+    }
+)(_cross_entropy_backward)
+
+
+class Fast_CrossEntropyLoss(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, labels, logit_softcapping: float = 0, logit_scaling: float = 0):
+        n_rows, vocab_size = logits.shape
+        device = logits.device
+        labels = labels.to(device)
+
+        div, mod = divmod(vocab_size, MAX_FUSED_SIZE)
+        n_chunks: int = div + (mod != 0)
+        losses = torch.empty(n_rows, dtype=torch.float32, device=device)
+
+        do_softcapping = bool(logit_softcapping != 0)
+        do_logit_scaling = bool(logit_scaling != 0)
+
+        if n_chunks == 1:
+            block_size, num_warps = calculate_settings(vocab_size)
+            if is_cdna():
+                num_warps = num_warps // 2
+            logsumexp = torch.empty(n_rows, dtype=torch.float32, device=device)
+
+            with torch_gpu_device(device):
+                _cross_entropy_forward[(n_rows,)](
+                    logits,
+                    logits.stride(0),
+                    losses,
+                    logsumexp,
+                    labels,
+                    VOCAB_SIZE=vocab_size,
+                    BLOCK_SIZE=block_size,
+                    DO_SOFTCAPPING=do_softcapping,
+                    SOFTCAP=logit_softcapping,
+                    DO_LOGIT_SCALING=do_logit_scaling,
+                    LOGIT_SCALE=logit_scaling,
+                    num_warps=num_warps,
+                )
+        else:
+            logsumexp = torch.empty((n_rows, n_chunks), dtype=torch.float32, device=device)
+
+            with torch_gpu_device(device):
+                _chunked_cross_entropy_forward[(n_rows, n_chunks)](
+                    logits,
+                    logits.stride(0),
+                    losses,
+                    logsumexp,
+                    labels,
+                    VOCAB_SIZE=vocab_size,
+                    N_CHUNKS=n_chunks,
+                    BLOCK_SIZE=MAX_FUSED_SIZE,
+                    DO_SOFTCAPPING=do_softcapping,
+                    SOFTCAP=logit_softcapping,
+                    DO_LOGIT_SCALING=do_logit_scaling,
+                    LOGIT_SCALE=logit_scaling,
+                    num_warps=32 if not is_cdna() else 16,
+                )
+            logsumexp = torch.logsumexp(logsumexp, dim=1)
+            losses += logsumexp
+            losses.masked_fill_(labels == -100, 0)
+
+        ctx.save_for_backward(logits, logsumexp, labels)
+        ctx.DO_SOFTCAPPING = do_softcapping
+        ctx.logit_softcapping = logit_softcapping
+        ctx.DO_LOGIT_SCALING = do_logit_scaling
+        ctx.logit_scaling = logit_scaling
+        return losses
+
+    @staticmethod
+    def backward(ctx, dlosses):
+        logits, logsumexp, labels = ctx.saved_tensors
+        n_rows, vocab_size = logits.shape
+
+        block_size: int = 4096
+        div, mod = divmod(vocab_size, block_size)
+        n_blocks: int = div + (mod != 0)
+
+        with torch_gpu_device(dlosses.device):
+            _cross_entropy_backward[(n_rows, n_blocks)](
+                logits,
+                logits.stride(0),
+                dlosses,
+                dlosses.stride(0),
+                logsumexp,
+                labels,
+                VOCAB_SIZE=vocab_size,
+                BLOCK_SIZE=block_size,
+                DO_SOFTCAPPING=ctx.DO_SOFTCAPPING,
+                SOFTCAP=ctx.logit_softcapping,
+                DO_LOGIT_SCALING=ctx.DO_LOGIT_SCALING,
+                LOGIT_SCALE=ctx.logit_scaling,
+                num_warps=8,
+            )
+        return logits, None, None, None
+
+
+def fast_cross_entropy_loss(logits, labels, logit_softcapping=0, logit_scaling=0, n_items=None):
+    batch, seq_len, d = logits.shape
+    assert labels.shape == (batch, seq_len)
+
+    device = logits.device
+    loss = Fast_CrossEntropyLoss.apply(
+        logits.view(batch * seq_len, d),
+        labels.view(-1),
+        logit_softcapping,
+        logit_scaling,
+    )
+    if n_items is None:
+        n_items = torch.count_nonzero(labels != -100)
+    if torch.is_tensor(n_items):
+        n_items = n_items.to(device)
+    return loss.sum() / n_items

--- a/unturtle/kernels/fast_lora.py
+++ b/unturtle/kernels/fast_lora.py
@@ -32,13 +32,13 @@ from __future__ import annotations
 
 import torch
 
-from unsloth.kernels.fast_lora import (
+from ._fast_lora_core import (
     LoRA_QKV,
-    apply_lora_qkv,  # re-export for convenience
+    apply_lora_qkv,
     apply_lora_o,
     apply_lora_mlp_swiglu,
 )
-from unsloth.kernels.utils import (
+from ._fast_lora_utils import (
     _maybe_fake_quantize_activations,
     fast_dequantize,
     get_lora_parameters_bias,
@@ -60,7 +60,7 @@ __all__ = [
 class LoRA_QKV_Bias(torch.autograd.Function):
     """Fused QKV LoRA with bias support.
 
-    Identical to :class:`unsloth.kernels.fast_lora.LoRA_QKV` except each
+    Identical to :class:`unturtle.kernels._fast_lora_core.LoRA_QKV` except each
     projection's bias is added after the matmul (forward) and the bias
     gradients are accumulated in backward.
 

--- a/unturtle/kernels/fused_masked_diffusion_loss.py
+++ b/unturtle/kernels/fused_masked_diffusion_loss.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 
 import torch
 import torch.nn.functional as F
-from unsloth.kernels.cross_entropy_loss import Fast_CrossEntropyLoss
+from unturtle.kernels.cross_entropy_loss import Fast_CrossEntropyLoss
 
 # Singleton -100 tensors reused across calls to avoid repeated scalar allocs.
 # Created lazily per device.

--- a/unturtle/kernels/rope_embedding.py
+++ b/unturtle/kernels/rope_embedding.py
@@ -1,0 +1,360 @@
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# Vendored from unsloth/kernels/rope_embedding.py for issue #67.
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from ._triton_utils import DEVICE_COUNT, calculate_settings, torch_device_stream, torch_gpu_device
+
+
+def _rope_embedding_QK(
+    Q,
+    Q_batch_stride,
+    Q_head_stride,
+    Q_seq_stride,
+    K,
+    K_batch_stride,
+    K_head_stride,
+    K_seq_stride,
+    cos,
+    cos_row_stride,
+    sin,
+    sin_row_stride,
+    rope_embedding_indices,
+    seqlen,
+    head_dim: tl.constexpr,
+    n_heads_K: tl.constexpr,
+    BACKWARD_PASS: tl.constexpr,
+    HAS_ROPE_INDICES: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    row_position = tl.program_id(0)
+    head_position = tl.program_id(1)
+    col_offsets = tl.arange(0, BLOCK_SIZE)
+    half_head_dim = head_dim // 2
+    mask = col_offsets < half_head_dim
+
+    if HAS_ROPE_INDICES:
+        rot_position = tl.load(
+            rope_embedding_indices + row_position,
+            eviction_policy="evict_first",
+        ).to(tl.int32)
+    else:
+        rot_position = row_position % seqlen
+
+    cos_ptr = cos + rot_position * cos_row_stride
+    sin_ptr = sin + rot_position * sin_row_stride
+    sin1 = tl.load(sin_ptr + col_offsets, mask=mask, other=0)
+    cos1 = tl.load(cos_ptr + col_offsets, mask=mask, other=0)
+    if BACKWARD_PASS:
+        sin1 = -sin1
+
+    batch_id = row_position // seqlen
+    seq_index = row_position - batch_id * seqlen
+
+    q_ptr = (
+        Q
+        + batch_id * Q_batch_stride
+        + head_position * Q_head_stride
+        + seq_index * Q_seq_stride
+    )
+    q0 = tl.load(q_ptr + col_offsets, mask=mask, other=0)
+    q1 = tl.load(q_ptr + half_head_dim + col_offsets, mask=mask, other=0)
+    tl.store(q_ptr + col_offsets, q0 * cos1 - q1 * sin1, mask=mask)
+    tl.store(q_ptr + half_head_dim + col_offsets, q1 * cos1 + q0 * sin1, mask=mask)
+
+    if head_position < n_heads_K:
+        k_ptr = (
+            K
+            + batch_id * K_batch_stride
+            + head_position * K_head_stride
+            + seq_index * K_seq_stride
+        )
+        k0 = tl.load(k_ptr + col_offsets, mask=mask, other=0)
+        k1 = tl.load(k_ptr + half_head_dim + col_offsets, mask=mask, other=0)
+        tl.store(k_ptr + col_offsets, k0 * cos1 - k1 * sin1, mask=mask)
+        tl.store(k_ptr + half_head_dim + col_offsets, k1 * cos1 + k0 * sin1, mask=mask)
+
+
+_rope_embedding_QK = triton.jit(_rope_embedding_QK)
+_rope_embedding_QK = triton.heuristics(
+    {
+        "BACKWARD_PASS": lambda args: bool(args["BACKWARD_PASS"]),
+        "HAS_ROPE_INDICES": lambda args: bool(args["HAS_ROPE_INDICES"]),
+    }
+)(_rope_embedding_QK)
+
+ROPE_GROUP_SIZE: int = 4
+
+
+def _rope_embedding(
+    Q,
+    Q_row_stride: tl.constexpr,
+    cos,
+    cos_row_stride: tl.constexpr,
+    sin,
+    sin_row_stride: tl.constexpr,
+    seqlen,
+    head_dim: tl.constexpr,
+    n_heads: tl.constexpr,
+    BACKWARD_PASS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    ROPE_GROUP_SIZE = 4
+    row_position = tl.program_id(0)
+    group_head_position = tl.program_id(1)
+    col_offsets = tl.arange(0, BLOCK_SIZE)
+    half_head_dim = head_dim // 2
+    mask = col_offsets < half_head_dim
+
+    sin1 = tl.load(
+        sin + (row_position % seqlen) * sin_row_stride + col_offsets,
+        mask=mask,
+        other=0,
+    )
+    cos1 = tl.load(
+        cos + (row_position % seqlen) * cos_row_stride + col_offsets,
+        mask=mask,
+        other=0,
+    )
+
+    if BACKWARD_PASS:
+        sin1 = -sin1
+
+    head_start = group_head_position * ROPE_GROUP_SIZE
+    head_end = min((head_start + ROPE_GROUP_SIZE), n_heads)
+
+    for k in range(head_start, head_end):
+        offs_q1 = row_position * Q_row_stride + k * head_dim + col_offsets
+        offs_q2 = row_position * Q_row_stride + k * head_dim + col_offsets + half_head_dim
+
+        Q1 = tl.load(Q + offs_q1, mask=mask, other=0).to(sin1.dtype)
+        Q2 = tl.load(Q + offs_q2, mask=mask, other=0).to(sin1.dtype)
+
+        tl.store(Q + offs_q1, Q1 * cos1 - Q2 * sin1, mask=mask)
+        tl.store(Q + offs_q2, Q2 * cos1 + Q1 * sin1, mask=mask)
+
+
+_rope_embedding = triton.jit(_rope_embedding)
+_rope_embedding = triton.heuristics(
+    {
+        "BACKWARD_PASS": lambda args: bool(args["BACKWARD_PASS"]),
+    }
+)(_rope_embedding)
+
+
+class Fast_RoPE_Embedding(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, Q, cos, sin):
+        cos, sin = cos.squeeze(), sin.squeeze()
+        batch, seq_len, n_heads, head_dim = Q.shape
+        Q = Q.reshape(batch * seq_len, n_heads * head_dim)
+        n_rows, _ = Q.shape
+        assert seq_len <= cos.shape[0]
+
+        block_size, num_warps = calculate_settings(head_dim // 2)
+
+        div, mod = divmod(n_heads, ROPE_GROUP_SIZE)
+        n_groups: int = div + (mod != 0)
+
+        with torch_gpu_device(Q.device):
+            _rope_embedding[(n_rows, n_groups)](
+                Q,
+                Q.stride(0),
+                cos,
+                cos.stride(0),
+                sin,
+                sin.stride(0),
+                seq_len,
+                head_dim,
+                n_heads,
+                BACKWARD_PASS=False,
+                BLOCK_SIZE=block_size,
+                num_warps=num_warps,
+            )
+        ctx.BLOCK_SIZE = block_size
+        ctx.num_warps = num_warps
+        ctx.n_groups = n_groups
+        ctx.cos = cos
+        ctx.sin = sin
+        return Q.reshape(batch, seq_len, n_heads, head_dim)
+
+    @staticmethod
+    def backward(ctx, dY):
+        batch, seq_len, n_heads, head_dim = dY.shape
+        dY = dY.reshape(batch * seq_len, n_heads * head_dim)
+        n_rows, _ = dY.shape
+
+        with torch_gpu_device(dY.device):
+            _rope_embedding[(n_rows, ctx.n_groups)](
+                dY,
+                dY.stride(0),
+                ctx.cos,
+                ctx.cos.stride(0),
+                ctx.sin,
+                ctx.sin.stride(0),
+                seq_len,
+                head_dim,
+                n_heads,
+                BACKWARD_PASS=True,
+                BLOCK_SIZE=ctx.BLOCK_SIZE,
+                num_warps=ctx.num_warps,
+            )
+        dY = dY.reshape(batch, seq_len, n_heads, head_dim)
+        return dY, None, None
+
+
+@torch.compiler.disable
+def fast_rope_embedding(Q, K, cos, sin, rope_embedding_indices=None):
+    if rope_embedding_indices is not None:
+        Q_out, K_out = Fast_RoPE_Embedding_QK.apply(Q, K, cos, sin, rope_embedding_indices)
+    else:
+        Q_out = Fast_RoPE_Embedding.apply(Q.transpose(1, 2).contiguous(), cos, sin).transpose(1, 2)
+        K_out = Fast_RoPE_Embedding.apply(K.transpose(1, 2).contiguous(), cos, sin).transpose(1, 2)
+    if DEVICE_COUNT > 1:
+        torch_device_stream(Q.device).synchronize()
+    return Q_out, K_out
+
+
+class Fast_RoPE_Embedding_QK(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, Q, K, cos, sin, rope_indices):
+        has_indices = rope_indices is not None
+        cos, sin = cos.squeeze(), sin.squeeze()
+
+        batch, n_heads_Q, seq_len, head_dim = Q.shape
+        _, n_heads_K, _, _ = K.shape
+
+        Q_out = Q.clone() if not Q.is_contiguous() else Q
+        K_out = K.clone() if not K.is_contiguous() else K
+
+        if has_indices:
+            rope_ptr = rope_indices.reshape(-1).to(dtype=torch.int32, device=Q.device)
+        else:
+            rope_ptr = cos.new_empty(1, dtype=torch.int32)
+
+        block_size, num_warps = calculate_settings(head_dim)
+        Q_batch_stride, Q_head_stride, Q_seq_stride = Q_out.stride(0), Q_out.stride(1), Q_out.stride(2)
+        K_batch_stride, K_head_stride, K_seq_stride = K_out.stride(0), K_out.stride(1), K_out.stride(2)
+
+        with torch_gpu_device(Q.device):
+            _rope_embedding_QK[(batch * seq_len, n_heads_Q)](
+                Q_out,
+                Q_batch_stride,
+                Q_head_stride,
+                Q_seq_stride,
+                K_out,
+                K_batch_stride,
+                K_head_stride,
+                K_seq_stride,
+                cos,
+                cos.stride(0),
+                sin,
+                sin.stride(0),
+                rope_ptr,
+                seq_len,
+                head_dim=head_dim,
+                n_heads_K=n_heads_K,
+                BACKWARD_PASS=False,
+                HAS_ROPE_INDICES=has_indices,
+                BLOCK_SIZE=block_size,
+                num_warps=num_warps,
+            )
+
+        ctx.block_size = block_size
+        ctx.num_warps = num_warps
+        ctx.has_indices = has_indices
+        ctx.cos = cos
+        ctx.sin = sin
+        ctx.rope_indices = rope_ptr if has_indices else None
+        ctx.seq_len = seq_len
+        ctx.n_heads_Q = n_heads_Q
+        ctx.n_heads_K = n_heads_K
+        return Q_out, K_out
+
+    @staticmethod
+    def backward(ctx, dQ, dK):
+        batch, _, _, head_dim = dQ.shape
+        rope_ptr = ctx.rope_indices if ctx.has_indices else ctx.cos.new_empty(1, dtype=torch.int32)
+
+        dQ_out = dQ.clone() if not dQ.is_contiguous() else dQ
+        dK_out = dK.clone() if not dK.is_contiguous() else dK
+
+        Q_batch_stride, Q_head_stride, Q_seq_stride = dQ_out.stride(0), dQ_out.stride(1), dQ_out.stride(2)
+        K_batch_stride, K_head_stride, K_seq_stride = dK_out.stride(0), dK_out.stride(1), dK_out.stride(2)
+
+        with torch_gpu_device(dQ.device):
+            _rope_embedding_QK[(batch * ctx.seq_len, ctx.n_heads_Q)](
+                dQ_out,
+                Q_batch_stride,
+                Q_head_stride,
+                Q_seq_stride,
+                dK_out,
+                K_batch_stride,
+                K_head_stride,
+                K_seq_stride,
+                ctx.cos,
+                ctx.cos.stride(0),
+                ctx.sin,
+                ctx.sin.stride(0),
+                rope_ptr,
+                ctx.seq_len,
+                head_dim=head_dim,
+                n_heads_K=ctx.n_heads_K,
+                BACKWARD_PASS=True,
+                HAS_ROPE_INDICES=ctx.has_indices,
+                BLOCK_SIZE=ctx.block_size,
+                num_warps=ctx.num_warps,
+            )
+
+        return dQ_out, dK_out, None, None, None
+
+
+class Slow_RoPE_Embedding(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, Q, cos, sin, position_ids):
+        if position_ids is not None:
+            cos = cos.squeeze(1).squeeze(0)
+            sin = sin.squeeze(1).squeeze(0)
+            cos = cos[position_ids].unsqueeze(2)
+            sin = sin[position_ids].unsqueeze(2)
+
+        half = Q.shape[-1] // 2
+        RH_Q = torch.cat((-Q[..., half:], Q[..., :half]), dim=-1)
+        Q *= cos
+        Q.addcmul_(RH_Q, sin)
+        ctx.save_for_backward(cos, sin)
+        return Q
+
+    @staticmethod
+    def backward(ctx, dY):
+        cos, sin = ctx.saved_tensors
+        half = dY.shape[-1] // 2
+        RH_dY = torch.cat((dY[..., half:], -dY[..., :half]), dim=-1)
+        dY *= cos
+        dY.addcmul_(RH_dY, sin)
+        return dY, None, None, None
+
+
+def inplace_rope_embedding(Q, K, cos, sin, position_ids):
+    Q = Slow_RoPE_Embedding.apply(Q, cos, sin, position_ids)
+    K = Slow_RoPE_Embedding.apply(K, cos, sin, position_ids)
+    torch_device_stream(Q.device).synchronize()
+    return Q, K

--- a/unturtle/models/a2d/_fast_forward.py
+++ b/unturtle/models/a2d/_fast_forward.py
@@ -37,7 +37,7 @@ from typing import Optional, Tuple
 import torch
 from transformers.cache_utils import Cache
 
-from unsloth.kernels.rope_embedding import fast_rope_embedding
+from unturtle.kernels.rope_embedding import fast_rope_embedding
 from unsloth.utils.attention_dispatch import (
     HAS_FLASH_ATTENTION,
     SDPA,

--- a/unturtle/models/a2d/_fast_forward.py
+++ b/unturtle/models/a2d/_fast_forward.py
@@ -38,7 +38,7 @@ import torch
 from transformers.cache_utils import Cache
 
 from unturtle.kernels.rope_embedding import fast_rope_embedding
-from unsloth.utils.attention_dispatch import (
+from unturtle.utils.attention_dispatch import (
     HAS_FLASH_ATTENTION,
     SDPA,
     AttentionConfig,
@@ -46,7 +46,7 @@ from unsloth.utils.attention_dispatch import (
     run_attention,
     select_attention_backend,
 )
-from unsloth.utils.packing import get_packed_info_from_kwargs
+from unturtle.utils.packing import get_packed_info_from_kwargs
 
 if HAS_FLASH_ATTENTION:
     from flash_attn import flash_attn_varlen_func

--- a/unturtle/models/dream/modeling_dream.py
+++ b/unturtle/models/dream/modeling_dream.py
@@ -892,8 +892,9 @@ def _apply_dream_rope(
     """Apply RoPE to Dream query/key states.
 
     ``cos`` / ``sin`` are pre-indexed by ``position_ids`` (shape ``(B, L, head_dim)``
-    or ``(1, L, head_dim)``).  On CUDA we flatten to ``(B*L, head_dim)`` and use
-    a sequential row-index so that ``fast_rope_embedding`` does not double-index.
+    or ``(1, L, head_dim)``).  On CUDA we slice the first ``head_dim//2`` elements,
+    flatten to ``(B*L, head_dim//2)``, and use a sequential row-index so that
+    ``fast_rope_embedding`` does not double-index.
     On CPU we fall back to the plain ``apply_rotary_pos_emb`` path.
 
     Args:

--- a/unturtle/models/dream/modeling_dream.py
+++ b/unturtle/models/dream/modeling_dream.py
@@ -66,6 +66,12 @@ from transformers import PretrainedConfig
 from .configuration_dream import DreamConfig
 from .generation_utils import DreamGenerationMixin, DreamGenerationConfig
 
+try:
+    from unturtle.kernels.rope_embedding import fast_rope_embedding as _fast_rope_embedding
+    _HAS_FAST_ROPE = True
+except ImportError:
+    _HAS_FAST_ROPE = False
+
 if is_flash_attn_2_available():
     from transformers.modeling_flash_attention_utils import _flash_attention_forward
 
@@ -869,3 +875,102 @@ class DreamModel(DreamGenerationMixin, DreamPreTrainedModel):
             hidden_states=outputs.hidden_states,
             attentions=outputs.attentions,
         )
+
+
+# ---------------------------------------------------------------------------
+# Fast attention forward for Dream — Triton RoPE fast path
+# ---------------------------------------------------------------------------
+
+def _apply_dream_rope(
+    query_states: torch.Tensor,
+    key_states: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    bsz: int,
+    q_len: int,
+) -> tuple:
+    """Apply RoPE to Dream query/key states.
+
+    ``cos`` / ``sin`` are pre-indexed by ``position_ids`` (shape ``(B, L, head_dim)``
+    or ``(1, L, head_dim)``).  On CUDA we flatten to ``(B*L, head_dim)`` and use
+    a sequential row-index so that ``fast_rope_embedding`` does not double-index.
+    On CPU we fall back to the plain ``apply_rotary_pos_emb`` path.
+
+    Args:
+        query_states: ``(B, n_heads, L, head_dim)``
+        key_states:   ``(B, n_kv_heads, L, head_dim)``
+        cos, sin:     pre-indexed, shape ``(B, L, head_dim)`` or ``(1, L, head_dim)``
+    """
+    if _HAS_FAST_ROPE and query_states.device.type == "cuda" and cos.ndim == 3:
+        # fast_rope_embedding expects cos/sin of shape (rows, head_dim//2).
+        # DreamRotaryEmbedding returns (B, L, head_dim), so we take the first
+        # half before flattening (the kernel only reads head_dim//2 elements).
+        half = cos.shape[-1] // 2
+        cos_flat = cos[..., :half].reshape(-1, half).contiguous()  # (B*L, head_dim//2)
+        sin_flat = sin[..., :half].reshape(-1, half).contiguous()  # (B*L, head_dim//2)
+        rope_indices = torch.arange(bsz * q_len, device=query_states.device, dtype=torch.long)
+        query_states, key_states = _fast_rope_embedding(
+            query_states, key_states, cos_flat, sin_flat, rope_indices
+        )
+    else:
+        query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
+    return query_states, key_states
+
+
+def DreamAttention_fast_forward(
+    self,
+    hidden_states: torch.Tensor,
+    attention_mask: Optional[torch.Tensor] = None,
+    position_ids: Optional[torch.LongTensor] = None,
+    past_key_value=None,
+    output_attentions: bool = False,
+    use_cache: bool = False,
+    cache_position: Optional[torch.LongTensor] = None,
+    position_embeddings: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+    **kwargs,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
+    """Drop-in replacement for ``DreamAttention.forward`` with Triton RoPE fast path.
+
+    Replaces ``apply_rotary_pos_emb`` with ``_apply_dream_rope`` which uses
+    ``fast_rope_embedding`` on CUDA (flatten + sequential row index, no double-index).
+    The rest of the forward pass is unchanged.
+
+    Injected by ``FastDiffusionModel._patch_dream_peft`` when the model is on CUDA.
+    """
+    bsz, q_len, _ = hidden_states.size()
+
+    query_states, key_states, value_states = self.apply_qkv(self, hidden_states)
+
+    query_states = query_states.view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
+    key_states = key_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
+    value_states = value_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
+
+    if position_embeddings is None:
+        cos, sin = self.rotary_emb(value_states, position_ids)
+    else:
+        cos, sin = position_embeddings
+
+    query_states, key_states = _apply_dream_rope(query_states, key_states, cos, sin, bsz, q_len)
+
+    if past_key_value is not None:
+        cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
+        key_states, value_states = past_key_value.update(key_states, value_states, self.layer_idx, cache_kwargs)
+
+    key_states = repeat_kv(key_states, self.num_key_value_groups)
+    value_states = repeat_kv(value_states, self.num_key_value_groups)
+
+    attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) / math.sqrt(self.head_dim)
+    if attention_mask is not None:
+        causal_mask = attention_mask[:, :, :, : key_states.shape[-2]]
+        attn_weights = attn_weights + causal_mask
+
+    attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query_states.dtype)
+    attn_weights = nn.functional.dropout(attn_weights, p=self.attention_dropout, training=self.training)
+    attn_output = torch.matmul(attn_weights, value_states)
+
+    attn_output = self.apply_o(self, attn_output.transpose(1, 2).contiguous().reshape(bsz, q_len, self.hidden_size))
+
+    if not output_attentions:
+        attn_weights = None
+
+    return attn_output, attn_weights, past_key_value

--- a/unturtle/save.py
+++ b/unturtle/save.py
@@ -1,0 +1,150 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Saving utilities for unturtle models.
+
+Adapted from unsloth/save.py — the push_to_hub wrapper is changed to tag
+models with "unturtle" instead of "unsloth".
+"""
+
+from __future__ import annotations
+
+import inspect
+import types
+
+
+def patch_saving_functions(model, vision: bool = False):
+    """Patch ``push_to_hub`` and related methods on a PEFT model.
+
+    Wraps ``push_to_hub`` so that "unturtle" is appended to the model's tags
+    and to the commit message / description when pushing to HuggingFace Hub.
+
+    Also delegates the heavier merged/GGUF/GGML/TorchAO save methods back to
+    the upstream ``unsloth.save`` implementation so that those workflows still
+    work without requiring a full re-port here.
+
+    Args:
+        model:  PEFT-wrapped model returned by ``FastDiffusionModel.get_peft_model``.
+        vision: Unused; kept for API compatibility with the unsloth version.
+    """
+    # Determine the original (un-patched) push_to_hub
+    if (
+        hasattr(model, "push_to_hub")
+        and model.push_to_hub.__name__ == "_unturtle_push_to_hub"
+        and hasattr(model, "original_push_to_hub")
+    ):
+        # Already patched; no-op
+        return model
+
+    # Walk the model chain and patch each push_to_hub
+    original_model = model
+    while True:
+        if (
+            hasattr(original_model, "push_to_hub")
+            and original_model.push_to_hub.__name__ != "_unturtle_push_to_hub"
+        ):
+            original_model.original_push_to_hub = original_model.push_to_hub
+            original_model.push_to_hub = types.MethodType(
+                _unturtle_push_to_hub, original_model
+            )
+            if hasattr(original_model, "add_model_tags"):
+                original_model.add_model_tags(["unturtle"])
+
+        if hasattr(original_model, "model"):
+            original_model = original_model.model
+        else:
+            break
+
+    # Delegate heavier save methods to unsloth.save so they remain functional
+    try:
+        from unsloth.save import patch_saving_functions as _unsloth_patch
+
+        _unsloth_patch(model, vision=vision)
+    except (ImportError, Exception):
+        # If unsloth.save is not available, skip the extra methods silently.
+        pass
+
+    return model
+
+
+def _unturtle_push_to_hub(self, *args, **kwargs):
+    """push_to_hub wrapper that injects the 'unturtle' tag."""
+    # Collect all arguments via the original signature
+    sig = inspect.signature(self.original_push_to_hub)
+    bound = sig.bind(*args, **kwargs)
+    bound.apply_defaults()
+    arguments = dict(bound.arguments)
+
+    # Inject tag
+    if "tags" in arguments and arguments["tags"] is not None:
+        if isinstance(arguments["tags"], (list, tuple)):
+            if "unturtle" not in arguments["tags"]:
+                arguments["tags"] = list(arguments["tags"]) + ["unturtle"]
+    elif "tags" in arguments:
+        arguments["tags"] = ["unturtle"]
+    elif hasattr(self, "add_model_tags"):
+        self.add_model_tags(["unturtle"])
+
+    # Inject commit_message
+    if "commit_message" in arguments:
+        msg = arguments["commit_message"]
+        if msg is not None:
+            if not msg.endswith(" "):
+                msg += " "
+            if "Unturtle" not in msg:
+                msg += "(Trained with Unturtle)"
+        else:
+            msg = "Upload model trained with Unturtle"
+        arguments["commit_message"] = msg
+
+    # Inject commit_description
+    if "commit_description" in arguments:
+        desc = arguments["commit_description"]
+        if desc is not None:
+            if not desc.endswith(" "):
+                desc += " "
+            if "Unturtle" not in desc:
+                desc += "(Trained with Unturtle)"
+        else:
+            desc = "Upload model trained with Unturtle"
+        arguments["commit_description"] = desc
+
+    try:
+        return self.original_push_to_hub(**arguments)
+    except TypeError:
+        # Fallback: drop tags if the original method doesn't accept them
+        arguments.pop("tags", None)
+        return self.original_push_to_hub(**arguments)
+
+
+def prepare_model_for_kbit_training(
+    model,
+    use_gradient_checkpointing=True,
+    use_reentrant: bool = True,
+):
+    """Thin wrapper around ``peft.prepare_model_for_kbit_training``.
+
+    Accepts ``use_reentrant`` (used by the unsloth version) and maps it to
+    PEFT's ``gradient_checkpointing_kwargs``.
+    """
+    from peft import prepare_model_for_kbit_training as _peft_prepare
+
+    return _peft_prepare(
+        model,
+        use_gradient_checkpointing=use_gradient_checkpointing,
+        gradient_checkpointing_kwargs={"use_reentrant": use_reentrant},
+    )
+
+
+__all__ = ["patch_saving_functions", "prepare_model_for_kbit_training"]

--- a/unturtle/trainer.py
+++ b/unturtle/trainer.py
@@ -1,0 +1,621 @@
+# Copyright 2023-present Daniel Han-Chen & the Unsloth team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import psutil
+import warnings
+from dataclasses import dataclass, field
+from typing import Optional, List
+from functools import wraps
+
+import trl
+import inspect
+from trl import SFTTrainer
+from unturtle.utils._runtime import is_bfloat16_supported
+from unturtle.utils.packing import (
+    configure_padding_free,
+    configure_sample_packing,
+    enable_padding_free_metadata,
+    enable_sample_packing,
+)
+from unsloth_zoo.training_utils import (
+    unsloth_train as _unsloth_train,
+)
+from unsloth_zoo.vision_utils import (
+    UnslothVisionDataCollator,
+)
+from unsloth_zoo.hf_utils import get_transformers_model_type
+from unsloth_zoo.utils import Version
+import dataclasses
+
+__all__ = [
+    "UnslothTrainingArguments",
+    "UnslothTrainer",
+    "unsloth_train",
+    "_patch_trl_trainer",
+    "UnslothVisionDataCollator",
+    "QGaloreConfig",
+]
+
+logger = logging.getLogger(__name__)
+
+_AUTO_PADDING_FREE_ENV_DISABLED = os.environ.get(
+    "UNSLOTH_DISABLE_AUTO_PADDING_FREE", ""
+).strip().lower() in {"1", "true", "yes", "on"}
+
+PADDING_FREE_BLOCKLIST = {
+    "gemma2",  # - gemma2:  Uses slow_attention_softcapping which has torch.compile issues
+    "gpt_oss",  # - gpt_oss: Uses Flex Attention which doesn't handle padding_free correctly
+}
+
+
+def _should_pack(config) -> bool:
+    if config is None or not getattr(config, "packing", False):
+        return False
+    return not getattr(config, "_unsloth_disable_auto_packing", False)
+
+
+def _should_auto_padding_free(config) -> bool:
+    if (
+        config is None
+        or _AUTO_PADDING_FREE_ENV_DISABLED
+        or getattr(config, "packing", False)
+    ):
+        return False
+    return getattr(config, "padding_free", None) is None
+
+
+def _disable_sample_packing(config):
+    if config is None:
+        return
+    for attr, value in (("packing", False), ("padding_free", False)):
+        if hasattr(config, attr):
+            setattr(config, attr, value)
+    if hasattr(config, "remove_unused_columns"):
+        setattr(config, "remove_unused_columns", True)
+    setattr(config, "_unsloth_disable_auto_packing", True)
+
+
+_AUTO_PACK_SKIP_MESSAGES = (
+    "packing is not supported",
+    "padding-free training",
+    "passing a custom data collator",
+)
+
+
+def _should_skip_auto_packing_error(exc: Exception) -> bool:
+    message = str(exc).lower()
+    return any(msg in message for msg in _AUTO_PACK_SKIP_MESSAGES)
+
+
+# Unsloth gradient accumulation fix:
+from transformers import __version__ as transformers_version, ProcessorMixin
+
+if Version(transformers_version) > Version("4.45.2"):
+
+    def unsloth_train(trainer, *args, **kwargs):
+        return trainer.train(*args, **kwargs)
+
+else:
+
+    def unsloth_train(trainer, *args, **kwargs):
+        if len(args) != 0 or len(kwargs) != 0:
+            raise RuntimeError(
+                "Unsloth: Our custom gradient accumulation fixed trainer does not support other arguments.\n"
+                "If you want to use our fix inside of HF, please update `transformers` to the latest version via:\n"
+                "`pip uninstall transformers -y && pip install --upgrade --no-cache-dir transformers`"
+            )
+        print(
+            "Unsloth: Using our custom gradient accumulation fixed trainer, which is not feature complete.\n"
+            "If you want to use our fix inside of HF, please update `transformers` to the latest version via:\n"
+            "`pip uninstall transformers -y && pip install --upgrade --no-cache-dir transformers`"
+        )
+        return _unsloth_train(trainer)
+
+
+try:
+    from trl import SFTConfig as TrainingArguments
+except:
+    from transformers import TrainingArguments
+
+
+@dataclass
+class QGaloreConfig:
+    """Configuration for Q-GaLore optimizer integration.
+
+    Pass an instance of this class to ``UnslothTrainingArguments`` (via
+    ``q_galore_config``) to enable Q-GaLore training.
+    """
+
+    rank: int = 256
+    update_proj_gap: int = 200
+    scale: float = 0.25
+    proj_quant: bool = True
+    proj_quant_group_size: int = -1
+    proj_quant_n_bit: int = 4
+    weight_quant: bool = False
+    stochastic_round: bool = True
+    weight_group_size: int = 128
+    cos_threshold: float = 0.4
+    gamma_proj: float = 2.0
+    queue_size: int = 5
+    target_modules: Optional[List[str]] = None
+
+
+class UnslothTrainingArguments(TrainingArguments):
+    def __init__(
+        self,
+        embedding_learning_rate: float = None,
+        q_galore_config: Optional[QGaloreConfig] = None,
+        *args,
+        **kwargs,
+    ):
+        self.q_galore_config = q_galore_config
+        self.embedding_learning_rate = embedding_learning_rate
+        super().__init__(*args, **kwargs)
+        self.embedding_learning_rate = embedding_learning_rate
+
+
+def _create_unsloth_optimizer(
+    model,
+    optimizer_cls,
+    optimizer_kwargs,
+    embedding_lr = 5e-5,
+):
+    lr = optimizer_kwargs["lr"]
+    weight_decay = optimizer_kwargs.get("weight_decay", 0.0)
+
+    param_groups = {
+        "non_embeddings": {},
+        "embeddings": {},
+    }
+
+    for name, param in model.named_parameters():
+        if not param.requires_grad:
+            continue
+        if name.endswith("modules_to_save.default.weight"):
+            partial_name = name[: -len(".modules_to_save.default.weight")]
+            partial_name = partial_name[partial_name.rfind(".") + 1 :]
+            print(
+                f"Unsloth: Setting lr = {embedding_lr:.2e} instead of {lr:.2e} for {partial_name}."
+            )
+            param_groups["embeddings"][name] = param
+        else:
+            param_groups["non_embeddings"][name] = param
+
+    optimizer_grouped_parameters = [
+        {
+            "params": list(param_groups["non_embeddings"].values()),
+            "weight_decay": weight_decay,
+            "lr": lr,
+        },
+        {
+            "params": list(param_groups["embeddings"].values()),
+            "weight_decay": weight_decay,
+            "lr": embedding_lr,
+        },
+    ]
+    optimizer = optimizer_cls(optimizer_grouped_parameters, **optimizer_kwargs)
+    return optimizer
+
+
+class UnslothTrainer(SFTTrainer):
+    def create_optimizer(self):
+        # --- Q-GaLore optimizer ---
+        q_galore_config = getattr(self.args, "q_galore_config", None)
+        if q_galore_config is not None and self.optimizer is None:
+            embedding_lr = getattr(self.args, "embedding_learning_rate", None)
+            return self._create_q_galore_optimizer(q_galore_config, embedding_lr)
+
+        # --- Embedding-LR optimizer ---
+        embedding_learning_rate = getattr(self.args, "embedding_learning_rate", None)
+        if embedding_learning_rate is None:
+            return super().create_optimizer()
+
+        if self.optimizer is None:
+            optimizer_cls, optimizer_kwargs = SFTTrainer.get_optimizer_cls_and_kwargs(
+                self.args
+            )
+            self.optimizer = _create_unsloth_optimizer(
+                self.model,
+                optimizer_cls,
+                optimizer_kwargs,
+                embedding_learning_rate,
+            )
+        return self.optimizer
+
+    def _create_q_galore_optimizer(self, config: "QGaloreConfig", embedding_lr = None):
+        """Build the Q-GaLore optimizer from a QGaloreConfig."""
+        from unsloth.optimizers.q_galore_adamw import (
+            QGaLoreAdamW8bit,
+            make_q_galore_param_groups,
+            install_weight_quant_hooks,
+        )
+
+        lr = self.args.learning_rate
+        weight_decay = self.args.weight_decay
+
+        param_groups = make_q_galore_param_groups(
+            self.model,
+            lr = lr,
+            weight_decay = weight_decay,
+            rank = config.rank,
+            update_proj_gap = config.update_proj_gap,
+            scale = config.scale,
+            proj_quant = config.proj_quant,
+            proj_quant_group_size = config.proj_quant_group_size,
+            proj_quant_n_bit = config.proj_quant_n_bit,
+            weight_quant = config.weight_quant,
+            stochastic_round = config.stochastic_round,
+            weight_group_size = config.weight_group_size,
+            cos_threshold = config.cos_threshold,
+            gamma_proj = config.gamma_proj,
+            queue_size = config.queue_size,
+            target_modules = config.target_modules,
+        )
+
+        # --- Split embedding params with custom LR (Fix #2) ---
+        if embedding_lr is not None:
+            # Build a fast param->name lookup (O(N) instead of O(N*M))
+            param_to_name = {id(p): name for name, p in self.model.named_parameters()}
+
+            new_groups = []
+            for group in param_groups:
+                if "rank" in group:
+                    # GaLore group — keep as-is (embeddings are never in here)
+                    new_groups.append(group)
+                    continue
+                # Non-GaLore group: split out embedding params
+                embed_params = []
+                other_params = []
+                for p in group["params"]:
+                    # Check if this param belongs to a modules_to_save embedding
+                    name = param_to_name.get(id(p))
+                    if name and name.endswith("modules_to_save.default.weight"):
+                        partial_name = name[: -len(".modules_to_save.default.weight")]
+                        partial_name = partial_name[partial_name.rfind(".") + 1 :]
+                        print(
+                            f"Unsloth: Setting lr = {embedding_lr:.2e} instead of {lr:.2e} for {partial_name}."
+                        )
+                        embed_params.append(p)
+                    else:
+                        other_params.append(p)
+                if other_params:
+                    other_group = dict(group)
+                    other_group["params"] = other_params
+                    new_groups.append(other_group)
+                if embed_params:
+                    embed_group = dict(group)
+                    embed_group["params"] = embed_params
+                    embed_group["lr"] = embedding_lr
+                    new_groups.append(embed_group)
+            param_groups = new_groups
+
+        # --- Forward optimizer hyperparameters (Fix #3) ---
+        self.optimizer = QGaLoreAdamW8bit(
+            param_groups,
+            lr = lr,
+            weight_decay = weight_decay,
+            betas = (self.args.adam_beta1, self.args.adam_beta2),
+            eps = self.args.adam_epsilon,
+        )
+
+        # Initialize INT8 weight quantization if enabled
+        if config.weight_quant:
+            QGaLoreAdamW8bit.init_weight_quantization(
+                self.model,
+                param_groups,
+                group_size = config.weight_group_size,
+                stochastic = config.stochastic_round,
+            )
+            # Forward pre-hooks dequantize INT8 weights to float before each
+            # forward pass, allowing the optimizer to free float weight memory
+            # between steps.
+            install_weight_quant_hooks(self.model)
+
+        n_galore = sum(len(g["params"]) for g in param_groups if "rank" in g)
+        n_other = sum(len(g["params"]) for g in param_groups if "rank" not in g)
+        print(
+            f"🦥 Unsloth: Q-GaLore enabled — "
+            f"{n_galore} GaLore params (rank={config.rank}), "
+            f"{n_other} standard params."
+        )
+
+        return self.optimizer
+
+
+# From `trl>=0.13.0`, they changed how to pass several params to the trainer
+# We need to patch to make the transition smooth
+def _resolve_trainer_params(trainer_class, init_fn):
+    """Resolve the real named parameters for a trainer __init__.
+
+    Some TRL trainers (e.g., ORPOTrainer in TRL 0.27.1) are thin wrappers
+    with only ``def __init__(self, *args, **kwargs)``.  For those, walk the
+    MRO and return the first parent class that has real named parameters.
+    """
+    params = inspect.signature(init_fn).parameters
+    named = {
+        k
+        for k, v in params.items()
+        if v.kind
+        in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+        and k != "self"
+    }
+    if named:
+        return set(params.keys())
+
+    # Thin wrapper detected - walk MRO for real signature
+    for cls in trainer_class.__mro__[1:]:
+        if cls is object:
+            continue
+        parent_init = cls.__dict__.get("__init__")
+        if parent_init is None:
+            continue
+        try:
+            parent_params = inspect.signature(parent_init).parameters
+            parent_named = {
+                k
+                for k, v in parent_params.items()
+                if v.kind
+                in (
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    inspect.Parameter.KEYWORD_ONLY,
+                )
+                and k != "self"
+            }
+            if parent_named:
+                return set(parent_params.keys())
+        except (ValueError, TypeError):
+            continue
+    return set(params.keys())
+
+
+def _backwards_compatible_trainer(trainer_class, config_class):
+    original_init = trainer_class.__init__
+
+    @wraps(original_init)
+    def new_init(self, *args, **kwargs):
+        # All Trainer tokenizer are now called processing_class
+        trainer_params = _resolve_trainer_params(trainer_class, original_init)
+
+        if "processing_class" in trainer_params and "tokenizer" in kwargs:
+            kwargs["processing_class"] = kwargs.pop("tokenizer")
+
+        if ("args" in kwargs) and (Version(trl) >= Version("0.13.0.dev0")):
+            training_args = kwargs.pop("args", None)
+
+            # Get parameters that Trainer.__init__ actually expects
+            trainer_params.remove("self")
+            trainer_params.remove("args")
+
+            # Get fields that should be passed to Config init
+            config_fields = {
+                field.name: field
+                for field in dataclasses.fields(config_class)
+                if field.init
+            }
+
+            # Create config dict with valid fields from training_args
+            config_dict = {
+                name: getattr(training_args, name)
+                for name in config_fields
+                if hasattr(training_args, name)
+            }
+
+            # Get parameters that exist in Config but not in TrainingArguments
+            from transformers import TrainingArguments
+
+            moved_params = set(inspect.signature(config_class).parameters.keys()) - set(
+                inspect.signature(TrainingArguments).parameters.keys()
+            )
+
+            # Separate kwargs into trainer kwargs and config kwargs
+            trainer_kwargs = {}
+            additional_config_kwargs = {}
+
+            for key, value in kwargs.items():
+                if key in trainer_params:
+                    trainer_kwargs[key] = value
+                elif key in moved_params or key in config_fields:
+                    additional_config_kwargs[key] = value
+                else:
+                    additional_config_kwargs[key] = value
+
+            # Update config_dict with additional kwargs
+            config_dict.update(additional_config_kwargs)
+
+            # Create Config with all the collected parameters
+            # Reinitialising config class with parameters (that were none initially but populated on first init)
+            # causes the 2nd init to fail as there are mutual exclusive checks on pairs of parameters.
+            # Refer: https://github.com/huggingface/trl/blob/main/trl/trainer/grpo_config.py#L499-L502 for example
+            # So we only create config class if the previous init was not TrainingArguments
+            if not isinstance(training_args, TrainingArguments):
+                config = config_class(**config_dict)
+            else:
+                config = training_args
+
+            # Reconstruct kwargs for Trainer
+            kwargs = trainer_kwargs
+            kwargs["args"] = config
+        original_init(self, *args, **kwargs)
+
+    return new_init
+
+
+def _patch_sft_trainer_auto_packing(trl_module):
+    sft_trainer = getattr(trl_module, "SFTTrainer", None)
+    if sft_trainer is None:
+        return
+    if getattr(sft_trainer, "_unsloth_auto_packing_wrapped", False):
+        return
+
+    original_init = sft_trainer.__init__
+
+    @wraps(original_init)
+    def new_init(self, *args, **kwargs):
+        config_arg = None
+        if len(args) >= 2:
+            config_arg = args[1]
+        else:
+            config_arg = kwargs.get("args")
+
+        # Check if model type is unsupported for padding_free
+        model = kwargs.get("model")
+        is_unsupported_model = False
+        is_vlm = False
+        if model is not None:
+            model_config = getattr(model, "config", None)
+            if model_config is not None:
+                model_types = get_transformers_model_type(model_config)
+                # Blocklist: models that don't work correctly with padding_free
+                is_unsupported_model = any(
+                    x in PADDING_FREE_BLOCKLIST for x in model_types
+                )
+
+                # Check if VLM
+                architectures = getattr(model_config, "architectures", None)
+                if architectures is None:
+                    architectures = []
+                is_vlm = any(
+                    x.endswith("ForConditionalGeneration") for x in architectures
+                )
+                is_vlm = is_vlm or hasattr(model_config, "vision_config")
+
+        processing_class = kwargs.get("processing_class") or kwargs.get("tokenizer")
+        data_collator = kwargs.get("data_collator")
+
+        # We also disable vision language models for padding free collators
+        blocked = (
+            (data_collator is not None)
+            or isinstance(processing_class, ProcessorMixin)
+            or is_vlm
+            or is_unsupported_model
+            or (
+                os.environ.get("UNSLOTH_RETURN_LOGITS", "0") == "1"
+            )  # Disable padding free on forced logits
+        )
+        requested_pack = bool(getattr(config_arg, "packing", False))
+        if blocked:
+            if hasattr(config_arg, "packing"):
+                setattr(config_arg, "packing", False)
+            if hasattr(config_arg, "padding_free"):
+                setattr(config_arg, "padding_free", False)
+
+        if blocked and requested_pack:
+            reason = "custom data collator"
+            if data_collator is None and isinstance(processing_class, ProcessorMixin):
+                reason = "processor-based model"
+            elif is_vlm:
+                reason = "vision-language model"
+            elif is_unsupported_model:
+                reason = f"unsupported model type(s): {', '.join(model_types)}"
+            message = "Unsloth: Sample packing skipped " f"({reason} detected)."
+            print(message)
+
+        packing_active = False
+        if _should_pack(config_arg) and not blocked:
+            configure_sample_packing(config_arg)
+            packing_active = True
+            logger.info("Unsloth: Sample packing enabled for SFTTrainer instance.")
+
+        # Resolve padding_free: None (default) = auto-enable unless env-disabled or packing
+        auto_padding_free_active = False
+        padding_free_requested = getattr(config_arg, "padding_free", None) is True
+        if not blocked:
+            if padding_free_requested:
+                configure_padding_free(config_arg)
+            elif _should_auto_padding_free(config_arg):
+                configure_padding_free(config_arg)
+                auto_padding_free_active = True
+                logger.info(
+                    "Unsloth: Padding-free batching auto-enabled for SFTTrainer instance."
+                )
+
+        try:
+            original_init(self, *args, **kwargs)
+        except ValueError as exc:
+            if packing_active and _should_skip_auto_packing_error(exc):
+                logger.info(
+                    "Unsloth: Auto sample packing failed because trainer reported an incompatible setup (%s).",
+                    exc,
+                )
+                _disable_sample_packing(config_arg)
+                packing_active = False
+                original_init(self, *args, **kwargs)
+            else:
+                raise
+
+        trainer_args = getattr(self, "args", None)
+        trainer_packing = bool(trainer_args and getattr(trainer_args, "packing", False))
+        trainer_padding_free = bool(
+            trainer_args and getattr(trainer_args, "padding_free", False)
+        )
+
+        if blocked and trainer_args is not None:
+            # Mirror the block on the trainer args to avoid re-enabling later
+            setattr(trainer_args, "packing", False)
+            setattr(trainer_args, "padding_free", False)
+
+        if (
+            not blocked
+            and trainer_packing
+            and (packing_active or _should_pack(trainer_args))
+        ):
+            enable_sample_packing(self.model, self)
+            print(
+                "🦥 Unsloth: Packing enabled - training is >2x faster and uses less VRAM!"
+            )
+        elif not blocked and trainer_padding_free:
+            enable_padding_free_metadata(self.model, self)
+            message = (
+                "🦥 Unsloth: Padding-free auto-enabled, enabling faster training."
+                if auto_padding_free_active
+                else "🦥 Unsloth: Padding-free enabled, enabling faster training."
+            )
+            print(message)
+
+    sft_trainer.__init__ = new_init
+    sft_trainer._unsloth_auto_packing_wrapped = True
+
+
+def _patch_trl_trainer():
+    import trl
+
+    if hasattr(trl, "__UNSLOTH_BACKWARDS_COMPATIBLE__"):
+        return
+    if Version(trl) <= Version("0.11.0"):
+        return
+
+    import trl.trainer
+
+    trl_classes = dir(trl.trainer)
+    trl_trainers = set(
+        x[: -len("Trainer")] for x in trl_classes if x.endswith("Trainer")
+    )
+    trl_configs = set(x[: -len("Config")] for x in trl_classes if x.endswith("Config"))
+    trl_classes = list(trl_trainers & trl_configs)
+
+    for x in trl_classes:
+        try:
+            exec(
+                f"trl.{x}Trainer.__init__ = _backwards_compatible_trainer(trl.{x}Trainer, trl.{x}Config)",
+                globals(),
+            )
+        except:
+            continue
+
+    _patch_sft_trainer_auto_packing(trl)
+
+    trl.__UNSLOTH_BACKWARDS_COMPATIBLE__ = True

--- a/unturtle/utils/__init__.py
+++ b/unturtle/utils/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2025-present nishide-dev & the Unturtle team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unturtle-owned utility helpers vendored from unsloth as part of Phase Z."""
+

--- a/unturtle/utils/_runtime.py
+++ b/unturtle/utils/_runtime.py
@@ -1,0 +1,142 @@
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# Vendored from unsloth/models/_utils.py (Flash Attention + xFormers detection
+# sections only) for issue #67.
+
+"""Runtime hardware-capability detection for unturtle.
+
+Provides:
+  HAS_FLASH_ATTENTION  — True when flash_attn >= 2.x is usable on the current GPU
+  xformers             — the xformers.ops.fmha module or None
+  xformers_attention   — xformers.ops.fmha.memory_efficient_attention or None
+"""
+
+from __future__ import annotations
+
+import torch
+from packaging.version import Version
+from transformers.utils.import_utils import _is_package_available
+
+# ---------------------------------------------------------------------------
+# Device type
+# ---------------------------------------------------------------------------
+try:
+    _device_type: str = torch.device(torch.cuda.current_device()).type
+except Exception:
+    _device_type = "cpu"
+
+if torch.cuda.is_available():
+    _device_type = "cuda"
+
+# HIP / ROCm
+try:
+    if torch.version.hip is not None:
+        _device_type = "hip"
+except Exception:
+    pass
+
+# ---------------------------------------------------------------------------
+# Flash Attention
+# ---------------------------------------------------------------------------
+HAS_FLASH_ATTENTION = False
+HAS_FLASH_ATTENTION_SOFTCAPPING = False
+
+if _device_type in ("cuda", "hip"):
+    major_version, minor_version = torch.cuda.get_device_capability()
+    if major_version >= 8 or _device_type == "hip":
+        if _is_package_available("flash_attn"):
+            try:
+                try:
+                    from flash_attn.flash_attn_interface import flash_attn_gpu  # noqa: F401
+                except Exception:
+                    from flash_attn.flash_attn_interface import flash_attn_cuda  # noqa: F401
+                HAS_FLASH_ATTENTION = True
+
+                from flash_attn import __version__ as _flash_attn_version
+
+                HAS_FLASH_ATTENTION_SOFTCAPPING = Version(_flash_attn_version) >= Version(
+                    "2.6.3"
+                )
+            except Exception:
+                HAS_FLASH_ATTENTION = False
+
+# ---------------------------------------------------------------------------
+# xFormers
+# ---------------------------------------------------------------------------
+try:
+    from xformers import __version__ as _xformers_version
+
+    torch_version = torch.__version__.split("+")[0]
+    if Version(torch_version) < Version("2.2.0") and Version(
+        _xformers_version
+    ) >= Version("0.0.24"):
+        raise ImportError(
+            f"unturtle: torch={torch_version} but xformers={_xformers_version}; "
+            "please install xformers < 0.0.24 for this torch version."
+        )
+    if Version(torch_version) < Version("2.3.0") and Version(
+        _xformers_version
+    ) >= Version("0.0.26"):
+        raise ImportError(
+            f"unturtle: torch={torch_version} but xformers={_xformers_version}; "
+            "please install xformers < 0.0.26 for this torch version."
+        )
+    if Version(torch_version) < Version("2.4.0") and Version(
+        _xformers_version
+    ) > Version("0.0.27"):
+        raise ImportError(
+            f"unturtle: torch={torch_version} but xformers={_xformers_version}; "
+            "please install xformers <= 0.0.27 for this torch version."
+        )
+
+    # xformers FA3 dispatch broken on Blackwell+ before 0.0.33
+    if torch.cuda.is_available():
+        _cc = torch.cuda.get_device_capability()
+        if f"{_cc[0]}.{_cc[1]}" in ("10.0", "11.0", "12.0") and Version(
+            _xformers_version
+        ) <= Version("0.0.32.post2"):
+            raise ImportError(
+                f"unturtle: xformers {_xformers_version} has a broken FA3 dispatch on "
+                f"SM {_cc[0]}.{_cc[1]}; please upgrade to >= 0.0.33."
+            )
+
+    from xformers._cpp_lib import _register_extensions
+
+    try:
+        _register_extensions()
+    except Exception as _e:
+        raise ImportError(
+            "unturtle: xformers was not installed correctly.\n"
+            "Please run: python -m xformers.info\n\n"
+            "Longer error: " + str(_e)
+        ) from _e
+
+    import xformers.ops.fmha as xformers  # type: ignore[assignment]
+
+    xformers_attention = xformers.memory_efficient_attention
+except ModuleNotFoundError:
+    xformers = None
+    xformers_attention = None
+except Exception:
+    xformers = None
+    xformers_attention = None
+
+__all__ = [
+    "HAS_FLASH_ATTENTION",
+    "HAS_FLASH_ATTENTION_SOFTCAPPING",
+    "xformers",
+    "xformers_attention",
+]

--- a/unturtle/utils/_runtime.py
+++ b/unturtle/utils/_runtime.py
@@ -134,9 +134,21 @@ except Exception:
     xformers = None
     xformers_attention = None
 
+SUPPORTS_BFLOAT16: bool = False
+if _device_type in ("cuda", "hip") and torch.cuda.is_available():
+    _major, _ = torch.cuda.get_device_capability()
+    SUPPORTS_BFLOAT16 = _major >= 8
+
+
+def is_bfloat16_supported() -> bool:
+    return SUPPORTS_BFLOAT16
+
+
 __all__ = [
     "HAS_FLASH_ATTENTION",
     "HAS_FLASH_ATTENTION_SOFTCAPPING",
+    "SUPPORTS_BFLOAT16",
+    "is_bfloat16_supported",
     "xformers",
     "xformers_attention",
 ]

--- a/unturtle/utils/attention_dispatch.py
+++ b/unturtle/utils/attention_dispatch.py
@@ -1,0 +1,324 @@
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# Vendored from unsloth/utils/attention_dispatch.py for issue #67.
+
+"""Shared helpers for attention backend selection and execution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional, Tuple
+
+import torch
+from torch import Tensor
+from torch.nn.functional import scaled_dot_product_attention
+
+from unsloth.models._utils import HAS_FLASH_ATTENTION, xformers, xformers_attention
+
+from .packing import (
+    build_sdpa_packed_attention_mask,
+    build_xformers_block_causal_mask,
+)
+
+if HAS_FLASH_ATTENTION:
+    from flash_attn import flash_attn_func, flash_attn_varlen_func
+else:
+    flash_attn_func = None
+    flash_attn_varlen_func = None
+HAS_XFORMERS = xformers is not None
+
+if HAS_XFORMERS and torch.cuda.is_available():
+    _cc = torch.cuda.get_device_capability()
+    if _cc[0] >= 12:
+        HAS_XFORMERS = False
+SDPA_HAS_GQA = "enable_gqa" in (scaled_dot_product_attention.__doc__ or "")
+
+FLASH_VARLEN = "flash_varlen"
+FLASH_DENSE = "flash_dense"
+XFORMERS = "xformers"
+SDPA = "sdpa"
+
+
+XFORMERS_BLOCK_DIAG_CLS = (
+    xformers.attn_bias.BlockDiagonalCausalMask if HAS_XFORMERS else None
+)
+
+
+@dataclass
+class AttentionConfig:
+    backend: str
+    n_kv_heads: int
+    n_groups: int
+    flash_dense_kwargs: Optional[dict[str, Any]] = None
+    flash_varlen_kwargs: Optional[dict[str, Any]] = None
+    sdpa_kwargs: Optional[dict[str, Any]] = None
+    xformers_kwargs: Optional[dict[str, Any]] = None
+
+
+@dataclass
+class AttentionContext:
+    bsz: int
+    q_len: int
+    kv_seq_len: int
+    n_heads: int
+    head_dim: int
+    requires_grad: bool
+    seq_info: Optional[Tuple[Tensor, Tensor, int]]
+    attention_mask: Optional[Tensor]
+    causal_mask: Optional[Any]
+    sliding_window: Optional[int] = None
+
+
+def select_attention_backend(use_varlen: bool = False) -> str:
+    if HAS_FLASH_ATTENTION:
+        if use_varlen:
+            return FLASH_VARLEN
+        return FLASH_DENSE
+    if HAS_XFORMERS:
+        return XFORMERS
+    return SDPA
+
+
+def run_attention(
+    *,
+    config: AttentionConfig,
+    context: AttentionContext,
+    Q: Tensor,
+    K: Tensor,
+    V: Tensor,
+) -> Tensor:
+    backend = config.backend
+    if backend == FLASH_VARLEN and context.seq_info is None:
+        backend = FLASH_DENSE if HAS_FLASH_ATTENTION else SDPA
+
+    if context.attention_mask is not None and backend in (
+        FLASH_DENSE,
+        FLASH_VARLEN,
+        XFORMERS,
+    ):
+        backend = SDPA
+
+    flash_dense_kwargs = config.flash_dense_kwargs or {}
+    flash_varlen_kwargs = config.flash_varlen_kwargs or {}
+    sdpa_kwargs = config.sdpa_kwargs or {}
+    xformers_kwargs = config.xformers_kwargs or {}
+
+    bsz = context.bsz
+    n_heads = context.n_heads
+    q_len = context.q_len
+    head_dim = context.head_dim
+    kv_seq_len = context.kv_seq_len
+    requires_grad = context.requires_grad
+    sliding_window = context.sliding_window
+
+    if backend == FLASH_VARLEN:
+        Q_f = Q.transpose(1, 2).reshape(bsz * q_len, n_heads, head_dim)
+        K_f = K.transpose(1, 2).reshape(bsz * q_len, config.n_kv_heads, head_dim)
+        V_f = V.transpose(1, 2).reshape(bsz * q_len, config.n_kv_heads, head_dim)
+        _, cu_seqlens, max_seqlen = context.seq_info
+        return flash_attn_varlen_func(
+            Q_f,
+            K_f,
+            V_f,
+            cu_seqlens,
+            cu_seqlens,
+            max_seqlen,
+            max_seqlen,
+            **flash_varlen_kwargs,
+        ).view(bsz, q_len, n_heads, head_dim)
+    if backend == FLASH_DENSE:
+        Q_t = Q.transpose(1, 2)
+        K_t = K.transpose(1, 2)
+        V_t = V.transpose(1, 2)
+        return flash_attn_func(Q_t, K_t, V_t, **flash_dense_kwargs).reshape(
+            bsz, q_len, n_heads, head_dim
+        )
+    if backend == XFORMERS:
+        attn_bias = build_xformers_block_causal_mask(
+            context.seq_info,
+            sliding_window=sliding_window,
+            base_mask=context.causal_mask,
+        )
+
+        Q_t = Q.transpose(1, 2)
+        K_t = K.transpose(1, 2)
+        V_t = V.transpose(1, 2)
+
+        K_mod = K_t
+        V_mod = V_t
+        Q_mod = Q_t
+
+        if config.n_groups != 1:
+            K_mod = K_t.view(bsz, kv_seq_len, config.n_kv_heads, 1, head_dim)
+            V_mod = V_t.view(bsz, kv_seq_len, config.n_kv_heads, 1, head_dim)
+            K_mod = K_mod.expand(
+                bsz, kv_seq_len, config.n_kv_heads, config.n_groups, head_dim
+            )
+            V_mod = V_mod.expand(
+                bsz, kv_seq_len, config.n_kv_heads, config.n_groups, head_dim
+            )
+
+            if requires_grad:
+                K_mod = K_mod.reshape(bsz, kv_seq_len, n_heads, head_dim)
+                V_mod = V_mod.reshape(bsz, kv_seq_len, n_heads, head_dim)
+            else:
+                Q_mod = Q_t.view(
+                    bsz, q_len, config.n_kv_heads, config.n_groups, head_dim
+                )
+
+        has_block = XFORMERS_BLOCK_DIAG_CLS is not None and isinstance(
+            attn_bias, XFORMERS_BLOCK_DIAG_CLS
+        )
+
+        if config.n_groups != 1 and has_block:
+            if not requires_grad:
+                Q_mod = Q_mod.view(
+                    1, bsz * q_len, config.n_kv_heads, config.n_groups, head_dim
+                )
+                K_mod = K_mod.view(
+                    1, bsz * kv_seq_len, config.n_kv_heads, config.n_groups, head_dim
+                )
+                V_mod = V_mod.view(
+                    1, bsz * kv_seq_len, config.n_kv_heads, config.n_groups, head_dim
+                )
+            else:
+                Q_mod = Q_mod.view(1, bsz * q_len, n_heads, head_dim)
+                K_mod = K_mod.view(1, bsz * kv_seq_len, n_heads, head_dim)
+                V_mod = V_mod.view(1, bsz * kv_seq_len, n_heads, head_dim)
+
+        out = xformers_attention(
+            Q_mod,
+            K_mod,
+            V_mod,
+            attn_bias=attn_bias,
+            **xformers_kwargs,
+        )
+
+        if config.n_groups != 1 and not requires_grad:
+            out = out.view(bsz, q_len, config.n_kv_heads, config.n_groups, head_dim)
+            out = out.reshape(bsz, q_len, n_heads, head_dim)
+        else:
+            out = out.view(bsz, q_len, n_heads, head_dim)
+        return out
+
+    local_mask = context.attention_mask
+    is_causal_local = False
+    if context.seq_info is not None and local_mask is None:
+        local_mask = build_sdpa_packed_attention_mask(
+            context.seq_info,
+            dtype=Q.dtype,
+            device=Q.device,
+            sliding_window=sliding_window,
+        )
+    else:
+        q_len_local = Q.shape[-2]
+        k_len_local = K.shape[-2]
+        if local_mask is not None and isinstance(local_mask, torch.Tensor):
+            local_mask = local_mask.to(device=Q.device)
+
+            if local_mask.dim() == 2:
+                if local_mask.dtype == torch.bool:
+                    key_keep = local_mask
+                else:
+                    key_keep = local_mask != 0
+
+                past_len = k_len_local - q_len_local
+                q_pos = torch.arange(
+                    past_len, past_len + q_len_local, device=Q.device
+                )
+                k_pos = torch.arange(k_len_local, device=Q.device)
+
+                causal_keep = k_pos[None, :] <= q_pos[:, None]
+                if sliding_window is not None:
+                    causal_keep &= k_pos[None, :] >= (
+                        q_pos[:, None] - (sliding_window - 1)
+                    )
+
+                local_mask = (
+                    causal_keep[None, None, :, :] & key_keep[:, None, None, :]
+                )
+
+            elif local_mask.dim() == 3:
+                local_mask = local_mask[:, None, :, :]
+
+            elif local_mask.dim() == 4:
+                if local_mask.dtype != torch.bool:
+                    local_mask = local_mask.eq(0)
+            else:
+                raise ValueError(
+                    f"Unsupported SDPA attention_mask rank: {local_mask.dim()}"
+                )
+
+            if local_mask.dtype == torch.bool:
+                no_allowed = ~local_mask.any(dim=-1, keepdim=True)
+                local_mask = local_mask | no_allowed
+
+        is_causal_local = local_mask is None and q_len_local == k_len_local
+
+    kwargs = dict(sdpa_kwargs)
+    kwargs.setdefault("attn_mask", local_mask)
+    kwargs.setdefault("is_causal", is_causal_local)
+
+    use_sdpa_gqa = SDPA_HAS_GQA and config.n_groups != 1
+    if (
+        use_sdpa_gqa
+        and (not requires_grad)
+        and isinstance(local_mask, torch.Tensor)
+        and local_mask.dim() >= 3
+        and local_mask.shape[0] > 1
+    ):
+        use_sdpa_gqa = False
+
+    if use_sdpa_gqa:
+        kwargs.setdefault("enable_gqa", True)
+        out = scaled_dot_product_attention(Q, K, V, **kwargs)
+        return out.transpose(1, 2)
+
+    K_mod = K
+    V_mod = V
+    if config.n_groups != 1:
+        K_mod = K[:, :, None, :, :].expand(
+            bsz, config.n_kv_heads, config.n_groups, kv_seq_len, head_dim
+        )
+        V_mod = V[:, :, None, :, :].expand(
+            bsz, config.n_kv_heads, config.n_groups, kv_seq_len, head_dim
+        )
+        K_mod = K_mod.reshape(bsz, n_heads, kv_seq_len, head_dim)
+        V_mod = V_mod.reshape(bsz, n_heads, kv_seq_len, head_dim)
+
+    out = scaled_dot_product_attention(
+        Q.contiguous(),
+        K_mod.contiguous(),
+        V_mod.contiguous(),
+        **kwargs,
+    )
+    return out.transpose(1, 2).contiguous()
+
+
+__all__ = [
+    "AttentionConfig",
+    "AttentionContext",
+    "FLASH_DENSE",
+    "FLASH_VARLEN",
+    "HAS_FLASH_ATTENTION",
+    "HAS_XFORMERS",
+    "SDPA",
+    "XFORMERS",
+    "build_sdpa_packed_attention_mask",
+    "build_xformers_block_causal_mask",
+    "run_attention",
+    "select_attention_backend",
+]

--- a/unturtle/utils/attention_dispatch.py
+++ b/unturtle/utils/attention_dispatch.py
@@ -26,7 +26,7 @@ import torch
 from torch import Tensor
 from torch.nn.functional import scaled_dot_product_attention
 
-from unsloth.models._utils import HAS_FLASH_ATTENTION, xformers, xformers_attention
+from ._runtime import HAS_FLASH_ATTENTION, xformers, xformers_attention
 
 from .packing import (
     build_sdpa_packed_attention_mask,

--- a/unturtle/utils/packing.py
+++ b/unturtle/utils/packing.py
@@ -1,0 +1,410 @@
+# Copyright 2023-present Daniel Han-Chen, Michael Han-Chen & the Unsloth team. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# Vendored from unsloth/utils/packing.py for issue #67.
+
+"""Utilities for enabling packed (padding-free) batches across Unturtle."""
+
+from __future__ import annotations
+
+import logging
+from collections import OrderedDict
+from typing import Any, Iterable, Optional, Sequence, Tuple
+
+import torch
+
+try:
+    from xformers.ops.fmha.attn_bias import (
+        BlockDiagonalCausalMask as _XFormersBlockMask,
+    )
+except Exception:
+    try:
+        from xformers.attn_bias import BlockDiagonalCausalMask as _XFormersBlockMask
+    except Exception:
+        _XFormersBlockMask = None
+
+_XFORMERS_MASK_CACHE_MAXSIZE = 32
+_XFORMERS_MASK_CACHE: OrderedDict[Tuple[Tuple[int, ...], int], Any] = OrderedDict()
+
+# Cache per device for get_packed_info_from_kwargs to avoid repeated D2H sync across layers
+_PACKED_INFO_CACHE: dict = {}
+
+# Cache per device for build_sdpa_packed_attention_mask to avoid repeated D2H sync across layers
+_SDPA_MASK_CACHE: dict = {}
+
+# Cache per device for build_xformers_block_causal_mask to avoid repeated D2H sync across layers
+_XFORMERS_BLOCK_MASK_CACHE: dict = {}
+
+
+def _window_cache_key(sliding_window: Optional[int]) -> int:
+    if sliding_window is None or sliding_window <= 0:
+        return 0
+    return int(sliding_window)
+
+
+def _get_cached_block_mask(
+    lengths: Tuple[int, ...],
+    sliding_window: Optional[int],
+):
+    if _XFormersBlockMask is None:
+        return None
+
+    window_key = _window_cache_key(sliding_window)
+    cache_key = (lengths, window_key)
+    cached = _XFORMERS_MASK_CACHE.get(cache_key)
+    if cached is not None:
+        _XFORMERS_MASK_CACHE.move_to_end(cache_key)
+        return cached
+
+    mask = _XFormersBlockMask.from_seqlens(list(lengths))
+    if window_key and mask is not None and hasattr(mask, "make_local_attention"):
+        mask = mask.make_local_attention(window_size=window_key)
+
+    _XFORMERS_MASK_CACHE[cache_key] = mask
+    if len(_XFORMERS_MASK_CACHE) > _XFORMERS_MASK_CACHE_MAXSIZE:
+        _XFORMERS_MASK_CACHE.popitem(last=False)
+    return mask
+
+
+class _TrlPackingWarningFilter(logging.Filter):
+    to_filter = (
+        "attention implementation is not",
+        "kernels-community",
+    )
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        message = record.getMessage()
+        return not any(substring in message for substring in self.to_filter)
+
+
+_TRL_FILTER_INSTALLED = False
+
+
+def _ensure_trl_warning_filter():
+    global _TRL_FILTER_INSTALLED
+    if _TRL_FILTER_INSTALLED:
+        return
+    logging.getLogger("trl.trainer.sft_trainer").addFilter(_TrlPackingWarningFilter())
+    _TRL_FILTER_INSTALLED = True
+
+
+def mark_allow_overlength(module):
+    """Mark a module hierarchy so padding-free batches can exceed max_seq_length."""
+    if module is None:
+        return
+    if hasattr(module, "max_seq_length"):
+        setattr(module, "_unsloth_allow_packed_overlength", True)
+    children = getattr(module, "children", None)
+    if children is None:
+        return
+    for child in children():
+        mark_allow_overlength(child)
+
+
+def configure_sample_packing(config):
+    """Mutate an ``SFTConfig`` so TRL prepares packed batches."""
+    _ensure_trl_warning_filter()
+    setattr(config, "packing", True)
+    setattr(config, "padding_free", True)
+    setattr(config, "remove_unused_columns", False)
+
+
+def configure_padding_free(config):
+    """Mutate an ``SFTConfig`` so TRL enables padding-free batching without packing."""
+    _ensure_trl_warning_filter()
+    setattr(config, "padding_free", True)
+    setattr(config, "remove_unused_columns", False)
+
+
+def enable_sample_packing(
+    model,
+    trainer,
+    *,
+    sequence_lengths_key: str = "seq_lengths",
+) -> None:
+    """Enable runtime support for packed batches on an existing trainer."""
+    if model is None or trainer is None:
+        raise ValueError("model and trainer must not be None")
+
+    mark_allow_overlength(model)
+
+    if hasattr(trainer, "args") and hasattr(trainer.args, "remove_unused_columns"):
+        trainer.args.remove_unused_columns = False
+
+    collator = getattr(trainer, "data_collator", None)
+    if collator is None or not hasattr(collator, "torch_call"):
+        return
+    if getattr(collator, "_unsloth_packing_wrapped", False):
+        return
+
+    if hasattr(collator, "padding_free"):
+        collator.padding_free = True
+    if hasattr(collator, "return_position_ids"):
+        collator.return_position_ids = True
+
+    original_torch_call = collator.torch_call
+
+    def torch_call_with_lengths(examples: Sequence[dict]):
+        batch = original_torch_call(examples)
+        if examples and isinstance(examples[0], dict):
+            seq_lengths: list[int] = []
+            for example in examples:
+                lengths = example.get(sequence_lengths_key)
+                if isinstance(lengths, Iterable):
+                    seq_lengths.extend(int(length) for length in lengths)
+            if not seq_lengths:
+                for example in examples:
+                    ids = example.get("input_ids")
+                    if isinstance(ids, Iterable):
+                        seq_lengths.append(len(ids))
+            if seq_lengths:
+                batch["packed_seq_lengths"] = torch.tensor(
+                    seq_lengths, dtype=torch.int32
+                )
+                if "attention_mask" in batch:
+                    batch.pop("attention_mask")
+        return batch
+
+    collator.torch_call = torch_call_with_lengths
+    collator._unsloth_packing_wrapped = True
+
+
+def enable_padding_free_metadata(model, trainer):
+    """Inject seq-length metadata when padding-free batching is enabled without packing."""
+    collator = getattr(trainer, "data_collator", None)
+    if (
+        collator is None
+        or getattr(collator, "_unsloth_padding_free_lengths_wrapped", False)
+        or not getattr(collator, "padding_free", False)
+    ):
+        return
+
+    mark_allow_overlength(model)
+    if hasattr(collator, "return_position_ids"):
+        collator.return_position_ids = True
+    if hasattr(trainer, "args") and hasattr(trainer.args, "remove_unused_columns"):
+        trainer.args.remove_unused_columns = False
+
+    original_torch_call = collator.torch_call
+
+    def torch_call_with_padding_free_metadata(examples: Sequence[dict]):
+        seq_lengths: list[int] = []
+        if examples and isinstance(examples[0], dict):
+            for example in examples:
+                lengths = example.get("seq_lengths")
+                if lengths is None:
+                    ids = example.get("input_ids")
+                    if ids is None:
+                        continue
+                    lengths = [len(ids)]
+                    example["seq_lengths"] = lengths
+                seq_lengths.extend(lengths)
+
+        batch = original_torch_call(examples)
+        if seq_lengths:
+            batch["packed_seq_lengths"] = torch.tensor(
+                seq_lengths,
+                dtype=torch.int32,
+            )
+        return batch
+
+    collator.torch_call = torch_call_with_padding_free_metadata
+    collator._unsloth_padding_free_lengths_wrapped = True
+
+
+def get_packed_info_from_kwargs(
+    kwargs: dict,
+    device: torch.device,
+) -> Optional[Tuple[torch.Tensor, torch.Tensor, int]]:
+    """Return packed sequence metadata expected by the attention kernels."""
+
+    seq_lengths = kwargs.get("packed_seq_lengths")
+    if seq_lengths is None:
+        return None
+
+    entry = _PACKED_INFO_CACHE.get(device)
+    if entry is not None and entry["seq_lengths"] is seq_lengths:
+        return entry["result"]
+
+    lengths = seq_lengths.to(device=device, dtype=torch.int32, non_blocking=True)
+    cu_seqlens = torch.zeros(lengths.numel() + 1, dtype=torch.int32, device=device)
+    torch.cumsum(lengths, dim=0, dtype=torch.int32, out=cu_seqlens[1:])
+
+    max_seqlen = int(lengths.max().item())
+    result = (lengths, cu_seqlens, max_seqlen)
+    _PACKED_INFO_CACHE[device] = {"seq_lengths": seq_lengths, "result": result}
+    return result
+
+
+def build_xformers_block_causal_mask(
+    seq_info: Optional[Tuple[torch.Tensor, torch.Tensor, int]],
+    *,
+    sliding_window: Optional[int] = None,
+    base_mask: Optional[Any] = None,
+):
+    if _XFormersBlockMask is None:
+        return None
+    if seq_info is not None:
+        seq_lengths, _, _ = seq_info
+        device = seq_lengths.device
+        params = (sliding_window,)
+        entry = _XFORMERS_BLOCK_MASK_CACHE.get(device)
+        if (
+            entry is not None
+            and entry["seq_lengths"] is seq_lengths
+            and entry["params"] == params
+        ):
+            return entry["mask"]
+
+        lengths_tensor = seq_lengths.to("cpu", torch.int32)
+        if lengths_tensor.numel() == 0:
+            return None
+        lengths = tuple(int(x) for x in lengths_tensor.tolist())
+        mask = _get_cached_block_mask(lengths, sliding_window)
+
+        _XFORMERS_BLOCK_MASK_CACHE[device] = {
+            "seq_lengths": seq_lengths,
+            "params": params,
+            "mask": mask,
+        }
+    else:
+        mask = base_mask
+
+        if (
+            sliding_window is not None
+            and sliding_window > 0
+            and mask is not None
+            and hasattr(mask, "make_local_attention")
+        ):
+            mask = mask.make_local_attention(window_size=sliding_window)
+    return mask
+
+
+def build_sdpa_packed_attention_mask(
+    seq_info: Tuple[torch.Tensor, torch.Tensor, int],
+    *,
+    dtype: torch.dtype,
+    device: torch.device,
+    sliding_window: Optional[int] = None,
+) -> torch.Tensor:
+    seq_lengths, _, _ = seq_info
+
+    params = (dtype, sliding_window)
+    entry = _SDPA_MASK_CACHE.get(device)
+    if (
+        entry is not None
+        and entry["seq_lengths"] is seq_lengths
+        and entry["params"] == params
+    ):
+        return entry["mask"]
+
+    total_tokens = int(seq_lengths.sum().item())
+    mask = torch.full(
+        (total_tokens, total_tokens),
+        float("-inf"),
+        dtype=dtype,
+        device=device,
+    )
+    offset = 0
+    for length in seq_lengths.tolist():
+        length = int(length)
+        if length <= 0:
+            continue
+        block = torch.zeros((length, length), dtype=dtype, device=device)
+        upper = torch.triu(
+            torch.ones((length, length), device=device), diagonal=1
+        ).bool()
+        block = block.masked_fill(upper, float("-inf"))
+        if (
+            sliding_window is not None
+            and sliding_window > 0
+            and length > sliding_window
+        ):
+            idx = torch.arange(length, device=device)
+            dist = idx.unsqueeze(1) - idx.unsqueeze(0)
+            window_mask = dist >= sliding_window
+            block = block.masked_fill(window_mask, float("-inf"))
+        mask[offset : offset + length, offset : offset + length] = block
+        offset += length
+
+    result = mask.unsqueeze(0).unsqueeze(0)
+    _SDPA_MASK_CACHE[device] = {
+        "seq_lengths": seq_lengths,
+        "params": params,
+        "mask": result,
+    }
+    return result
+
+
+def _normalize_packed_lengths(
+    seq_lengths: Any,
+    *,
+    device: torch.device,
+) -> Optional[torch.Tensor]:
+    if seq_lengths is None:
+        return None
+    if isinstance(seq_lengths, torch.Tensor):
+        lengths = seq_lengths.to(device=device, dtype=torch.int64)
+    else:
+        lengths = torch.tensor(seq_lengths, device=device, dtype=torch.int64)
+    if lengths.ndim != 1:
+        lengths = lengths.reshape(-1)
+    if lengths.numel() == 0:
+        return None
+    return lengths
+
+
+def mask_packed_sequence_boundaries(
+    shift_labels: torch.Tensor,
+    seq_lengths: Any,
+    *,
+    ignore_index: int = -100,
+) -> bool:
+    """Mark final token of every packed sample so CE ignores boundary predictions."""
+    lengths = _normalize_packed_lengths(seq_lengths, device=shift_labels.device)
+    if lengths is None:
+        return False
+
+    flat = shift_labels.reshape(-1)
+    total_tokens = flat.shape[0]
+    boundary_positions = torch.cumsum(lengths, dim=0) - 1
+    valid = boundary_positions < total_tokens
+    if not torch.all(valid):
+        boundary_positions = boundary_positions[valid]
+    if boundary_positions.numel() == 0:
+        return False
+    flat[boundary_positions] = ignore_index
+    return True
+
+
+def clear_packed_caches():
+    """Release cached masks/metadata to free device memory."""
+    _PACKED_INFO_CACHE.clear()
+    _SDPA_MASK_CACHE.clear()
+    _XFORMERS_BLOCK_MASK_CACHE.clear()
+
+
+__all__ = [
+    "configure_sample_packing",
+    "configure_padding_free",
+    "enable_sample_packing",
+    "enable_padding_free_metadata",
+    "mark_allow_overlength",
+    "get_packed_info_from_kwargs",
+    "build_xformers_block_causal_mask",
+    "build_sdpa_packed_attention_mask",
+    "mask_packed_sequence_boundaries",
+    "clear_packed_caches",
+]


### PR DESCRIPTION
## Summary

- `DreamAttention_fast_forward` を `modeling_dream.py` に追加。CUDA 時に `fast_rope_embedding` (Triton) による RoPE fast path を使い、CPU では `apply_rotary_pos_emb` にフォールバック
- `_apply_dream_rope` ヘルパー: `DreamRotaryEmbedding` が返す `(B, L, head_dim)` の cos/sin を `head_dim//2` に切り詰めて `fast_rope_embedding` に渡す（カーネルは前半のみ読むため）
- `_patch_dream_peft` で CUDA 上の全 Dream attention layer に forward を inject
- `TestDreamFastRoPE` テストクラスを追加: CPU parity, reset position_ids, CUDA/CPU parity, no double-index の 4 テスト

## Key Implementation Note

`LlamaRotaryEmbedding` (A2D 用) は `(B, L, head_dim//2)` を返すが、`DreamRotaryEmbedding` は `cat(freqs, freqs)` で `(B, L, head_dim)` を返す。`fast_rope_embedding` は前半 `head_dim//2` しか読まないため、Dream では `cos[..., :head_dim//2].reshape(-1, head_dim//2)` が必要。

また `fast_rope_embedding` は in-place 操作のため、CPU/CUDA 比較テストでは `.clone()` が必須（CLAUDE.md gotchas に追記）。

## Test plan

- [x] `python -m pytest tests/models/test_dream.py -v` — 14 passed
- [x] `python -m pytest tests/models/test_a2d.py tests/test_fast_diffusion_model.py -q` — 86 passed, 1 skipped

Closes #64